### PR TITLE
remove 'packages' definition

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -55,11 +55,6 @@ defines:
       (This really should be a config option and not a layer option.)
     type: string
 
-  packages:
-    description: >
-      A list of apt packages to be installed during setup.
-    type: array
-    items: {type: string}
   groups:
     description: >
       A list of system groups to be created during setup.


### PR DESCRIPTION
This is handled by layer-basic and was copy pasta'd.  I did a quick scan of the layers including this one, and did not find any referencing 'packages' as a bigtop-base layer option.  I'm like, 99% sure this is safe to remove.