### PR TITLE
Smoke tests

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,5 @@
+smoke-test:
+    description: |
+      Verify a Bigtop service is working by executing a smoke test. The
+      specific components to test should be configured via the
+      'bigtop_smoketest_components' layer option.

--- a/actions/smoke-test
+++ b/actions/smoke-test
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 import sys
+sys.path.append('lib')
 
 from charmhelpers.core import hookenv
 from charmhelpers.core.host import chdir, chownr
@@ -40,9 +41,9 @@ if not smoke_components:
 # so we can create a .gradle subdir.
 chownr(bigtop.bigtop_base, 'ubuntu', 'ubuntu', chowntopdir=True)
 with chdir(bigtop.bigtop_base):
-    for component in smoke_components.split():
+    for component in smoke_components:
         hookenv.log('Running smoke test: {}'.format(component))
-        run_as('ubuntu', './gradlew', 'bigtop-tests:smoke-tests:{0}:test -Psmoke.tests --info'.
-               format(component))
+        run_as('ubuntu', './gradlew', 'bigtop-tests:smoke-tests:{0}:test'.format(component),
+               '-Psmoke.tests', '--info')
 
 hookenv.action_set({'outcome': 'success'})

--- a/actions/smoke-test
+++ b/actions/smoke-test
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+from charmhelpers.core import chdir, hookenv
+from charms import layer
+from charms.layer.apache_bigtop_base import Bigtop
+from charms.reactive import is_state
+from jujubigdata.utils import run_as
+
+if not is_state('bigtop.available'):
+    hookenv.action_fail('Bigtop is not yet ready')
+
+
+bigtop = Bigtop()
+cfg = layer.options('apache-bigtop-base')
+smoke_components = cfg.get('bigtop_smoketest_components')
+if not smoke_components:
+    hookenv.action_fail('No bigtop_smoketest_components found for this charm')
+    sys.exit()
+
+# Within the unpacked Bigtop release directory, run the existing component smoker
+# with Bigtop's gradle wrapper script
+with chdir(bigtop.bigtop_base):
+    for component in smoke_components.split():
+        hookenv.log('Running smoke test: {}'.format(component))
+        run_as('ubuntu', './gradlew', 'bigtop-tests:smoke-tests:{0}:test -Psmoke.tests --info'.
+               format(component))
+
+hookenv.action_set({'outcome': 'success'})

--- a/actions/smoke-test
+++ b/actions/smoke-test
@@ -17,7 +17,8 @@
 
 import sys
 
-from charmhelpers.core import chdir, hookenv
+from charmhelpers.core import hookenv
+from charmhelpers.core.host import chdir, chownr
 from charms import layer
 from charms.layer.apache_bigtop_base import Bigtop
 from charms.reactive import is_state
@@ -35,7 +36,9 @@ if not smoke_components:
     sys.exit()
 
 # Within the unpacked Bigtop release directory, run the existing component smoker
-# with Bigtop's gradle wrapper script
+# with Bigtop's gradle wrapper script. Ensure the base dir is owned by ubuntu
+# so we can create a .gradle subdir.
+chownr(bigtop.bigtop_base, 'ubuntu', 'ubuntu', chowntopdir=True)
 with chdir(bigtop.bigtop_base):
     for component in smoke_components.split():
         hookenv.log('Running smoke test: {}'.format(component))

--- a/actions/smoke-test
+++ b/actions/smoke-test
@@ -15,35 +15,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+################################################################################
+# Bigtop smoke test template
+#
+# This provides basic Bigtop smoke test capabilities. This should be modified
+# as needed for individual charms. Specifically, you should determine what
+# outcome is considered "succesful" and what warrants a "failure", and set
+# the action outcome/output as appropriate.
+################################################################################
 import sys
 sys.path.append('lib')
 
 from charmhelpers.core import hookenv
-from charmhelpers.core.host import chdir, chownr
 from charms import layer
 from charms.layer.apache_bigtop_base import Bigtop
 from charms.reactive import is_state
-from jujubigdata.utils import run_as
-
-if not is_state('bigtop.available'):
-    hookenv.action_fail('Bigtop is not yet ready')
 
 
-bigtop = Bigtop()
-cfg = layer.options('apache-bigtop-base')
-smoke_components = cfg.get('bigtop_smoketest_components')
-if not smoke_components:
-    hookenv.action_fail('No bigtop_smoketest_components found for this charm')
+def fail(msg, output):
+    hookenv.action_set({'output': output})
+    hookenv.action_fail(msg)
     sys.exit()
 
-# Within the unpacked Bigtop release directory, run the existing component smoker
-# with Bigtop's gradle wrapper script. Ensure the base dir is owned by ubuntu
-# so we can create a .gradle subdir.
-chownr(bigtop.bigtop_base, 'ubuntu', 'ubuntu', chowntopdir=True)
-with chdir(bigtop.bigtop_base):
-    for component in smoke_components:
-        hookenv.log('Running smoke test: {}'.format(component))
-        run_as('ubuntu', './gradlew', 'bigtop-tests:smoke-tests:{0}:test'.format(component),
-               '-Psmoke.tests', '--info')
+if not is_state('bigtop.available'):
+    fail('Bigtop is not yet ready')
 
-hookenv.action_set({'outcome': 'success'})
+cfg = layer.options('apache-bigtop-base')
+smoke_components = cfg.get('bigtop_smoketest_components')
+smoke_configs = cfg.get('bigtop_smoketest_configs')
+if not smoke_components:
+    fail('No bigtop_smoketest_components found for this charm')
+
+bigtop = Bigtop()
+result = bigtop.run_smoke_tests(smoke_components, smoke_configs)
+if result == 'success':
+    hookenv.action_set({'outcome': result})
+else:
+    fail('failed smoke testing: %s' % smoke_components, result)

--- a/layer.yaml
+++ b/layer.yaml
@@ -57,7 +57,7 @@ defines:
     items: {type: string}
     description: |
         A list of Bigtop components to exercise during the
-        smoke-test action. Availalbe components can be found at:
+        smoke-test action. Available components can be found at:
         https://github.com/apache/bigtop/tree/master/bigtop-tests/smoke-tests
 
   bigtop_smoketest_configs:

--- a/layer.yaml
+++ b/layer.yaml
@@ -56,9 +56,17 @@ defines:
     type: array
     items: {type: string}
     description: |
-        A list of bigtop components to exercise during the
+        A list of Bigtop components to exercise during the
         smoke-test action. Availalbe components can be found at:
         https://github.com/apache/bigtop/tree/master/bigtop-tests/smoke-tests
+
+  bigtop_smoketest_configs:
+    type: array
+    items: {type: string}
+    description: |
+        A list of files containing environment configuration required by
+        the Bigtop smoke tests configured above. For example,
+        '- /etc/default/hadoop'.
 
   hadoop_version:
     description: >

--- a/layer.yaml
+++ b/layer.yaml
@@ -53,10 +53,10 @@ defines:
     description: 'Hiera Bigtop config'
 
   bigtop_smoketest_components:
-    type: string
-    default: ''
+    type: array
+    items: {type: string}
     description: |
-        Space separated list of bigtop components to exercise during the
+        A list of bigtop components to exercise during the
         smoke-test action. Availalbe components can be found at:
         https://github.com/apache/bigtop/tree/master/bigtop-tests/smoke-tests
 

--- a/layer.yaml
+++ b/layer.yaml
@@ -52,6 +52,14 @@ defines:
     default: 'bigtop-deploy/puppet/hieradata/site.yaml'
     description: 'Hiera Bigtop config'
 
+  bigtop_smoketest_components:
+    type: string
+    default: ''
+    description: |
+        Space separated list of bigtop components to exercise during the
+        smoke-test action. Availalbe components can be found at:
+        https://github.com/apache/bigtop/tree/master/bigtop-tests/smoke-tests
+
   hadoop_version:
     description: >
       Version of the Hadoop libraries that should be installed.


### PR DESCRIPTION
This adds a smoke-test action to run the bigtop smoke tests when available.  The top layer charm should configure the bigtop_smoketest_components layer option to indicate which smoke tests should be run.

If a top layer charm does not have a bigtop smoke test, we should consider adding one to bigtop, or minimally include a smoke-test in that layer to override the one provided by this base layer.