### PR TITLE
BIGTOP-2478 Added patch for Zookeeper smoke tests

### DIFF
--- a/resources/BIGTOP-2478.patch
+++ b/resources/BIGTOP-2478.patch
@@ -1,0 +1,122 @@
+commit e44891fa6f74c3e7ebabbfb53aa9f957a76a485c
+Author: Pete Vander Giessen <petevg@gmail.com>
+Date:   Tue Jun 14 09:49:16 2016 -0400
+
+    BIGTOP-2478: Zookeeper does not have any smoke tests
+    
+    These tests are very basic for now. We just run "zkServer.sh status" and
+    verify that the output is reasonable.
+    
+    A lot of the more complex tests require multiple Zookeeper nodes to be
+    running, which is probably outside of the scope of a smoke test.
+
+diff --git a/bigtop-tests/smoke-tests/zookeeper/TestZookeeper.groovy b/bigtop-tests/smoke-tests/zookeeper/TestZookeeper.groovy
+new file mode 100644
+index 0000000..b0e5b37
+--- /dev/null
++++ b/bigtop-tests/smoke-tests/zookeeper/TestZookeeper.groovy
+@@ -0,0 +1,66 @@
++/**
++ * Licensed to the Apache Software Foundation (ASF) under one
++ * or more contributor license agreements.  See the NOTICE file
++ * distributed with this work for additional information
++ * regarding copyright ownership.  The ASF licenses this file
++ * to you under the Apache License, Version 2.0 (the
++ * "License"); you may not use this file except in compliance
++ * with the License.  You may obtain a copy of the License at
++ *
++ * http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++import org.junit.BeforeClass
++import org.junit.AfterClass
++
++import org.apache.bigtop.itest.shell.Shell
++import static org.junit.Assert.assertTrue
++import org.junit.Test
++import org.apache.commons.logging.LogFactory
++import org.apache.commons.logging.Log
++
++import static org.apache.bigtop.itest.LogErrorsUtils.logError
++
++class TestSpark {
++  static private Log LOG = LogFactory.getLog(Object.class)
++
++  static Shell sh = new Shell("/bin/bash -s")
++
++  @BeforeClass
++  static void setUp() {
++    // noop for now.
++  }
++
++  @AfterClass
++  public static void tearDown() {
++    // noop for now
++  }
++
++  @Test
++  void testZkServerStatus() {
++    // Basic test to verify that the server is running, and is in a
++    // state that we expect.
++    LOG.info('Running zkServer.sh status');
++    sh.exec("/usr/lib/zookeeper/bin/zkServer.sh status");
++    logError(sh);
++    assertTrue("Failed ...", sh.getRet() == 0);
++
++    String out = sh.getOut()[0].trim();
++    assertTrue(out.contains("Mode"));
++    // If this is the only Zookeeper node, then we should be in
++    // "standalone" mode. If not, we should be in "leader" or
++    // "follower" mode.
++    assertTrue(
++      out.contains("follower") ||
++      out.contains("leader") ||
++      out.contains("standalone")
++    );
++    LOG.info('zkServer.sh status checks out.');
++  }
++}
+diff --git a/bigtop-tests/smoke-tests/zookeeper/build.gradle b/bigtop-tests/smoke-tests/zookeeper/build.gradle
+new file mode 100644
+index 0000000..4e455cc
+--- /dev/null
++++ b/bigtop-tests/smoke-tests/zookeeper/build.gradle
+@@ -0,0 +1,32 @@
++/**
++ * Licensed to the Apache Software Foundation (ASF) under one
++ * or more contributor license agreements.  See the NOTICE file
++ * distributed with this work for additional information
++ * regarding copyright ownership.  The ASF licenses this file
++ * to you under the Apache License, Version 2.0 (the
++ * "License"); you may not use this file except in compliance
++ * with the License.  You may obtain a copy of the License at
++ *
++ * http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++def tests_to_include() {
++  return ["TestZookeeper.groovy"];
++}
++
++sourceSets {
++  test {
++    groovy {
++      srcDirs = ["./"]
++      exclude { FileTreeElement elem -> (doExclude(elem.getName())) }
++    }
++  }
++}
++
++test.doFirst {
++}

--- a/resources/BIGTOP-2478.patch
+++ b/resources/BIGTOP-2478.patch
@@ -45,7 +45,7 @@ index 0000000..b0e5b37
 +
 +import static org.apache.bigtop.itest.LogErrorsUtils.logError
 +
-+class TestSpark {
++class TestZookeeper {
 +  static private Log LOG = LogFactory.getLog(Object.class)
 +
 +  static Shell sh = new Shell("/bin/bash -s")


### PR DESCRIPTION
In combination with juju-solutions/layer-apache-bigtop-base/pull/22,
this adds Zookeeper smoke tests, and allows us to have a smoke-test
action in our Zookeeper charm.

@juju-solutions/bigdata 