### PR TITLE
Add a <charm>.yaml file to the hiera hierarchy

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -55,14 +55,6 @@ defines:
     default: 'bigtop-deploy/puppet/hieradata/'
     description: 'Path to hierdata .yaml files.'
 
-  bigtop_hiera_charmyaml:
-    type: string
-    default: ''
-    description: >
-      This yaml file will be inserted into the hiera hierarchy, just below
-      site.yaml. If this option is left as an empty string, I will use the
-      charm name.
-
   bigtop_smoketest_components:
     type: array
     items: {type: string}

--- a/layer.yaml
+++ b/layer.yaml
@@ -50,10 +50,18 @@ defines:
     default: 'bigtop-deploy/puppet/hiera.yaml'
     description: 'Hiera Bigtop config'
 
-  bigtop_hiera_siteyaml:
+  bigtop_hieradata_path:
     type: string
-    default: 'bigtop-deploy/puppet/hieradata/site.yaml'
-    description: 'Hiera Bigtop config'
+    default: 'bigtop-deploy/puppet/hieradata/'
+    description: 'Path to hierdata .yaml files.'
+
+  bigtop_hiera_charmyaml:
+    type: string
+    default: ''
+    description: >
+      This yaml file will be inserted into the hiera hierarchy, just below
+      site.yaml. If this option is left as an empty string, I will use the
+      charm name.
 
   bigtop_smoketest_components:
     type: array

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -100,7 +100,8 @@ class Bigtop(object):
         hiera_yaml[':yaml'][':datadir'] = str(self.hieradata_path)
 
         # insert <charm>.yaml into the hierarchy, after site.yaml
-        hiera_yaml[':hierarchy'].insert(1, self.charm_yaml)
+        if not self.charm_yaml in hiera_yaml[':hierarchy']:
+            hiera_yaml[':hierarchy'].insert(1, self.charm_yaml)
 
         # write the file (note: Hiera is a bit picky about the format of
         # the yaml file, so the default_flow_style=False is required)

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -19,7 +19,14 @@ class Bigtop(object):
     _roles = set()
     _overrides = {}
 
-    def __init__(self):
+    def __init__(self, charm_yaml=None):
+        '''
+        Initialize our Bigtop class.
+
+        @param str charm_yaml: name of the charm yaml file. Defaults to the
+            name of this charm.
+
+        '''
         self.bigtop_dir = '/home/ubuntu/bigtop.release'
         self.options = layer.options('apache-bigtop-base')
         self.bigtop_version = self.options.get('bigtop_version')
@@ -27,8 +34,10 @@ class Bigtop(object):
         # Get the name for our <charml>.yaml file. Strip off the file
         # extension, if any, as we do not want to write the full
         # filename to hiera.yaml:
-        self.charm_yaml = self.options.get('bigtop_hiera_charmyaml'.split(
-            '.yaml')[0]) or hookenv.metadata()['name']
+        if charm_yaml and charm_yaml.endswith('.yaml'):
+            # strip off the .yaml file extension
+            charm_yaml = charm_yaml[:-5]
+        self.charm_yaml = charm_yaml or hookenv.metadata()['name']
         self.hieradata_path = self.bigtop_base / self.options.get(
             'bigtop_hieradata_path')
 

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -24,13 +24,19 @@ class Bigtop(object):
         self.options = layer.options('apache-bigtop-base')
         self.bigtop_version = self.options.get('bigtop_version')
         self.bigtop_base = Path(self.bigtop_dir) / self.bigtop_version
-        self.site_yaml = self.bigtop_base / self.options.get('bigtop_hiera_siteyaml')
+        # Get the name for our <charml>.yaml file. Strip off the file
+        # extension, if any, as we do not want to write the full
+        # filename to hiera.yaml:
+        self.charm_yaml = self.options.get('bigtop_hiera_charmyaml'.split(
+            '.yaml')[0]) or hookenv.metadata()['name']
+        self.hieradata_path = self.bigtop_base / self.options.get(
+            'bigtop_hieradata_path')
 
     def install(self):
         """
         Install the base components of Apache Bigtop.
 
-        You will then need to call `render_site_yaml` to set up the correct
+        You will then need to call `render_charm_yaml` to set up the correct
         configuration and `trigger_puppet` to install the desired components.
         """
         self.check_reverse_dns()
@@ -71,7 +77,9 @@ class Bigtop(object):
 
     def render_hiera_yaml(self):
         """
-        Render the ``hiera.yaml`` file with the correct path to our ``site.yaml`` file.
+        Render the ``hiera.yaml`` file with the correct path to our
+        ``<charm>.yaml`` file.
+
         """
         hiera_src = self.bigtop_base / self.options.get('bigtop_hiera_config')
         hiera_dst = Path(self.options.get('bigtop_hiera_path'))
@@ -80,18 +88,27 @@ class Bigtop(object):
         hiera_yaml = yaml.load(hiera_src.text())
 
         # set the datadir
-        hiera_yaml[':yaml'][':datadir'] = str(self.site_yaml.dirname())
+        hiera_yaml[':yaml'][':datadir'] = str(self.hieradata_path)
+
+        # insert <charm>.yaml into the hierarchy, after site.yaml
+        hiera_yaml[':hierarchy'].insert(1, self.charm_yaml)
 
         # write the file (note: Hiera is a bit picky about the format of
         # the yaml file, so the default_flow_style=False is required)
         hiera_dst.write_text(yaml.dump(hiera_yaml, default_flow_style=False))
 
     def render_site_yaml(self, hosts=None, roles=None, overrides=None):
+        """Deprecated -- use render_charm_yaml in the future."""
+
+        return self.render_charm_yaml(hosts, roles, overrides)
+
+    def render_charm_yaml(self, hosts=None, roles=None, overrides=None):
         """
-        Render ``site.yaml`` file with appropriate Hiera data.
+        Render ``<charm>.yaml`` file with appropriate Hiera data.
 
         :param dict hosts: Mapping of host names to master addresses, which
-            will be used by `render_site_yaml` to create the configuration for Puppet.
+            will be used by `render_charm_yaml` to create the configuration
+            for Puppet.
 
             Currently supported names are:
 
@@ -107,7 +124,7 @@ class Bigtop(object):
             with a different set of hosts, the old hosts will be preserved.
 
         :param list roles: A list of roles this machine will perform, which
-            will be used by `render_site_yaml` to create the configuration for
+            will be used by `render_charm_yaml` to create the configuration for
             Puppet.
 
             If no roles are set, the ``bigtop_component_list`` layer option
@@ -119,7 +136,7 @@ class Bigtop(object):
             with a different set of roles, the old roles will be preserved.
 
         :param dict overrides: A dict of additional data to go in to the
-            ``site.yaml``, which will override data generated from `hosts`
+            ``<charm>.yaml``, which will override data generated from `hosts`
             and `roles`.
 
             Note that extra properties set by this are additive.  That is,
@@ -132,12 +149,16 @@ class Bigtop(object):
         if isinstance(roles, str):
             roles = [roles]
         overrides = overrides or {}
-        site_data = yaml.load(self.site_yaml.text())
+
+        # Fetch existing charm_yaml data, if any.
+        charm_yaml = self.hieradata_path / '{}.yaml'.format(self.charm_yaml)
+        charm_yaml.touch()  # Create the file if it doesn't exist
+        charm_data = yaml.load(charm_yaml.text()) or {}
 
         # define common defaults
         bigtop_apt = self.options.get('bigtop_repo-{}'.format(utils.cpu_arch()))
         hostname_check = unitdata.kv().get('reverse_dns_ok')
-        site_data.update({
+        charm_data.update({
             'bigtop::bigtop_repo_uri': bigtop_apt,
             'bigtop::jdk_preinstalled': True,
             'hadoop::hadoop_storage_dirs': ['/data/1', '/data/2'],
@@ -146,16 +167,16 @@ class Bigtop(object):
         })
 
         # update based on configuration type (roles vs components)
-        roles = set(roles) | set(site_data.get('bigtop::roles', []))
+        roles = set(roles) | set(charm_data.get('bigtop::roles', []))
         if roles:
-            site_data.update({
+            charm_data.update({
                 'bigtop::roles_enabled': True,
                 'bigtop::roles': sorted(roles),
             })
         else:
             gw_host = subprocess.check_output(['facter', 'fqdn']).strip().decode()
             cluster_components = self.options.get("bigtop_component_list").split()
-            site_data.update({
+            charm_data.update({
                 'bigtop::hadoop_gateway_node': gw_host,
                 'hadoop_cluster_node::cluster_components': cluster_components,
             })
@@ -178,21 +199,21 @@ class Bigtop(object):
         }
         for host in hosts.keys() & hosts_to_properties.keys():
             for prop in hosts_to_properties[host]:
-                site_data[prop] = hosts[host]
+                charm_data[prop] = hosts[host]
 
         # apply any additonal data / overrides
-        site_data.update(overrides)
+        charm_data.update(overrides)
 
         # write the file
-        self.site_yaml.dirname().makedirs_p()
-        self.site_yaml.write_text(yaml.dump(site_data, default_flow_style=False))
+        charm_yaml.dirname().makedirs_p()
+        charm_yaml.write_text(yaml.dump(charm_data, default_flow_style=False))
 
     def queue_puppet(self):
         """
         Queue a reactive handler that will call `trigger_puppet`.
 
         This is used to give any other concurrent handlers a chance to update
-        the ``site.yaml`` with new hosts, roles, or overrides.
+        the ``<charm>.yaml`` with new hosts, roles, or overrides.
         """
         set_state('apache-bigtop-base.puppet_queued')
 


### PR DESCRIPTION
This gives us the ability to override hiera values in a more appropriate
place than site.yaml.

@juju-solutions/bigdata What do people think? Is this what we had in mind?

I've tested this with Zookeeper, and it seems to do the right thing. 