### PR TITLE
multi series bigtop charms

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -19,8 +19,10 @@ defines:
 
   bigtop_version:
     type: string
-    default: 'bigtop-1.1.0'
-    description: 'Default version string of Bigtop release. Affects the location of Hiera bits and Puppet recipes'
+    default: '1.1.0'
+    description: |
+        Bigtop release version. Affects the location of Hiera bits, Puppet
+        recipes, and repository used for installing packages.
 
   bigtop_release_url:
     type: string
@@ -30,15 +32,13 @@ defines:
         This points to the official Apache Bigtop releases on of the ASF mirrors.
         The source code is needed in order to get access to project's Puppet recipes
 
-  bigtop_repo-x86_64:
+  bigtop_repo_url:
     type: string
-    default: 'http://bigtop-repos.s3.amazonaws.com/releases/1.1.0/ubuntu/trusty/x86_64'
-    description: URL to release apt repo for x86_64 platform
-
-  bigtop_repo-ppc64el:
-    type: string
-    default: 'http://bigtop-repos.s3.amazonaws.com/releases/1.1.0/ubuntu/vivid/ppc64el'
-    description: URL to release apt repo for ppc64el platform
+    default: 'http://bigtop-repos.s3.amazonaws.com/releases'
+    description: |
+        Base repo URL. The distro, series, architecture, and Bigtop version
+        will be appended to form the full URL to use for installing
+        Bigtop packages.
 
   bigtop_hiera_path:
     type: string

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,3 +2,6 @@ provides:
   java:
     interface: java
     scope: container
+series:
+  - trusty
+  - xenial


### PR DESCRIPTION
This combines the 2 repo layer opts into 1 base repo url. We then construct
the appropriate url using the deployed series and machine architecture.

At least, that's how it's supposed to work. At the moment, it seems there
is no xenial repo, so for now, we hard code trusty and vivid as appropriate.
Fortuantely, the trusty repo works for installing bigtop packages on xenial.

So, this PR adds the scaffolding to support proper run time construction of the
repo url in the future, and enables us to make all bigtop charms available for
trusty and xenial today.