### PR TITLE
Added a patch to allow kafka to bind to non default interface/ip

### DIFF
--- a/resources/bigtop-1.1.0/BIGTOP-1624.patch
+++ b/resources/bigtop-1.1.0/BIGTOP-1624.patch
@@ -1,7 +1,7 @@
-From bb11e062293f50dcbfbcde470f940f8a935c5027 Mon Sep 17 00:00:00 2001
+From 37db9367c5adf3620bb175ae2b722199e3d70eeb Mon Sep 17 00:00:00 2001
 From: Konstantinos Tsakalozos <konstantinos.tsakalozos@canonical.com>
 Date: Thu, 2 Jun 2016 13:36:23 +0300
-Subject: [PATCH] BIGTOP-1624 Adding kafka puppet scripts
+Subject: [PATCH] BIGTOP-1624: Add puppet recipes for deploying kafka
 
 ---
  bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml |   4 +
@@ -13,22 +13,25 @@ Subject: [PATCH] BIGTOP-1624 Adding kafka puppet scripts
  create mode 100644 bigtop-deploy/puppet/modules/kafka/templates/server.properties
 
 diff --git a/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml b/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
-index 71e01c7..ac63ed1 100644
+index 5c2c5f1..62256d5 100644
 --- a/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
 +++ b/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
-@@ -184,3 +184,7 @@ zeppelin::server::spark_master_url: "yarn-client"
+@@ -187,6 +187,10 @@ hadoop::common::tez_jars: "/usr/lib/tez"
+ # to enable tez in hive, uncomment the lines below
+ # hadoop_hive::client::hive_execution_engine: "tez"
+ 
++#kafka
++kafka::server::port: "9092"
++kafka::server::zookeeper_connection_string: "%{hiera('bigtop::hadoop_head_node')}:2181"
++
+ zeppelin::server::spark_master_url: "yarn-client"
  zeppelin::server::hiveserver2_url: "jdbc:hive2://%{hiera('hadoop-hive::common::hiveserver2_host')}:%{hiera('hadoop-hive::common::hiveserver2_port')}"
  zeppelin::server::hiveserver2_user: "%{hiera('bigtop::hiveserver2_user')}"
- zeppelin::server::hiveserver2_password: "%{hiera('bigtop::hiveserver2_password')}"
-+
-+kafka::server::broker_id: "0"
-+kafka::server::port: "9092"
-+kafka::server::zookeeper_connection_string: "localhost:2181"
 diff --git a/bigtop-deploy/puppet/manifests/cluster.pp b/bigtop-deploy/puppet/manifests/cluster.pp
-index ba980bd..b7a6bb7 100644
+index 9ff424c..12e0424 100644
 --- a/bigtop-deploy/puppet/manifests/cluster.pp
 +++ b/bigtop-deploy/puppet/manifests/cluster.pp
-@@ -113,6 +113,9 @@
+@@ -117,6 +117,9 @@
      worker => ["qfs-chunkserver"],
      client => ["qfs-client"],
    },
@@ -38,7 +41,7 @@ index ba980bd..b7a6bb7 100644
  }
  
  class hadoop_cluster_node (
-@@ -180,7 +183,8 @@
+@@ -185,7 +188,8 @@
      "tez",
      "ycsb",
      "kerberos",
@@ -50,7 +53,7 @@ index ba980bd..b7a6bb7 100644
    deploy_module { $modules:
 diff --git a/bigtop-deploy/puppet/modules/kafka/manifests/init.pp b/bigtop-deploy/puppet/modules/kafka/manifests/init.pp
 new file mode 100644
-index 0000000..97afd12
+index 0000000..f44b737
 --- /dev/null
 +++ b/bigtop-deploy/puppet/modules/kafka/manifests/init.pp
 @@ -0,0 +1,56 @@
@@ -78,9 +81,9 @@ index 0000000..97afd12
 +  }
 +
 +  class server(
-+      $broker_id,
-+      $port,
-+      $zookeeper_connection_string
++      $broker_id = "0",
++      $port = "9092",
++      $zookeeper_connection_string = "localhost:2181"
 +    ) {
 +
 +    package { 'kafka':

--- a/resources/bigtop-1.1.0/BIGTOP-2504.patch
+++ b/resources/bigtop-1.1.0/BIGTOP-2504.patch
@@ -1,0 +1,85 @@
+From 54104839c91e6fed9281967a8629d3f9ea27d68c Mon Sep 17 00:00:00 2001
+From: Pete Vander Giessen <petevg@gmail.com>
+Date: Tue, 19 Jul 2016 16:40:35 -0400
+Subject: [PATCH 1/2] Added bind_addr value for server.properties
+
+If set to something that ruby evaluates as true, will be written to
+server.properties. Causes the server to listen on the ip/interface
+indicated by the value of the string.
+---
+ bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml             | 1 +
+ bigtop-deploy/puppet/modules/kafka/manifests/init.pp           | 3 ++-
+ bigtop-deploy/puppet/modules/kafka/templates/server.properties | 4 ++++
+ 3 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml b/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
+index 55f5bcd..d6246fd 100644
+--- a/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
++++ b/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
+@@ -191,6 +191,7 @@ hadoop::common::tez_jars: "/usr/lib/tez"
+ #kafka
+ kafka::server::port: "9092"
+ kafka::server::zookeeper_connection_string: "%{hiera('bigtop::hadoop_head_node')}:2181"
++kafka::server::bind_addr: ""
+ 
+ zeppelin::server::spark_master_url: "yarn-client"
+ zeppelin::server::hiveserver2_url: "jdbc:hive2://%{hiera('hadoop-hive::common::hiveserver2_host')}:%{hiera('hadoop-hive::common::hiveserver2_port')}"
+diff --git a/bigtop-deploy/puppet/modules/kafka/manifests/init.pp b/bigtop-deploy/puppet/modules/kafka/manifests/init.pp
+index f44b737..3394481 100644
+--- a/bigtop-deploy/puppet/modules/kafka/manifests/init.pp
++++ b/bigtop-deploy/puppet/modules/kafka/manifests/init.pp
+@@ -24,7 +24,8 @@ class kafka {
+   class server(
+       $broker_id = "0",
+       $port = "9092",
+-      $zookeeper_connection_string = "localhost:2181"
++      $zookeeper_connection_string = "localhost:2181",
++      $bind_addr = ""
+     ) {
+ 
+     package { 'kafka':
+diff --git a/bigtop-deploy/puppet/modules/kafka/templates/server.properties b/bigtop-deploy/puppet/modules/kafka/templates/server.properties
+index a30e970..626c52f 100644
+--- a/bigtop-deploy/puppet/modules/kafka/templates/server.properties
++++ b/bigtop-deploy/puppet/modules/kafka/templates/server.properties
+@@ -25,7 +25,11 @@ broker.id=<%= @broker_id %>
+ port=<%= @port %>
+ 
+ # Hostname the broker will bind to. If not set, the server will bind to all interfaces
++<% if @bind_addr %>
++host.name=<%= @bind_addr %>
++<% else %>
+ #host.name=localhost
++<% end %>
+ 
+ # Hostname the broker will advertise to producers and consumers. If not set, it uses the
+ # value for "host.name" if configured.  Otherwise, it will use the value returned from
+-- 
+2.7.4
+
+
+From aeb429fa5c541835d6f3507867329cc470239b8c Mon Sep 17 00:00:00 2001
+From: Pete Vander Giessen <petevg@gmail.com>
+Date: Thu, 21 Jul 2016 13:33:55 -0400
+Subject: [PATCH 2/2] Fixes to puppet recipes.
+
+---
+ bigtop-deploy/puppet/modules/kafka/templates/server.properties | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bigtop-deploy/puppet/modules/kafka/templates/server.properties b/bigtop-deploy/puppet/modules/kafka/templates/server.properties
+index 626c52f..6e85413 100644
+--- a/bigtop-deploy/puppet/modules/kafka/templates/server.properties
++++ b/bigtop-deploy/puppet/modules/kafka/templates/server.properties
+@@ -25,7 +25,7 @@ broker.id=<%= @broker_id %>
+ port=<%= @port %>
+ 
+ # Hostname the broker will bind to. If not set, the server will bind to all interfaces
+-<% if @bind_addr %>
++<% if !@bind_addr.nil? && !@bind_addr.empty? %>
+ host.name=<%= @bind_addr %>
+ <% else %>
+ #host.name=localhost
+-- 
+2.7.4
+


### PR DESCRIPTION
@juju-solutions/bigdata 

This is one of three pull requests for setting up the ability to bind kafka to an interface/ip address. I've run bundletester with the following permutations of 'bind_addr' in config.yaml:

1) Keeping the default value of null doesn't break anything, which is expected.
2) Passing in a value of 0.0.0.0 doesn't break anything, which is expected.
3) Passing in an address that doesn't match the address of the kafka server (e.g., 10.0.9.9) does break things.

My juju fu is not strong enough to setup a second interface on a machine and bind to that, but the above three tests do seem to indicate that the code does what I think that it does.

As part of this work, I also fixed up the kafka tests. It should be easy to get them to run, even if you aren't paying attention to anything other than having the right branch of layer-apache-bigtop-base checked out locally. (The branch is 'kafka-bind-address', incidentally)