### PR TITLE
Added ability to reset interface bindings.

### DIFF
--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -53,9 +53,14 @@ class Bigtop(object):
 
         @param str network_interface: either the name of the
         interface, or a CIDR range, in which we expect the interface's
-        ip to fall.
+        ip to fall. Also accepts 0.0.0.0 as a special case, which will
+        simply return 0.0.0.0.
 
         """
+        if network_interface == '0.0.0.0':
+            # Allow users to reset the charm to listening on any interface.
+            return network_interface
+
         # Is this a CIDR range, or an interface name?
         is_cidr = len(network_interface.split(".")) == 4 or len(network_interface.split(":")) == 8
 

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -57,12 +57,15 @@ class Bigtop(object):
         simply return 0.0.0.0.
 
         """
-        if network_interface == '0.0.0.0':
-            # Allow users to reset the charm to listening on any interface.
+        if network_interface.startswith('0') or network_interface == '::':
+            # Allow users to reset the charm to listening on any
+            # interface.  Allow operators to specify this however they
+            # wish (0.0.0.0, ::, 0/0, etc.).
             return network_interface
 
         # Is this a CIDR range, or an interface name?
-        is_cidr = len(network_interface.split(".")) == 4 or len(network_interface.split(":")) == 8
+        is_cidr = len(network_interface.split(".")) == 4 or len(
+            network_interface.split(":")) == 8
 
         if is_cidr:
             interfaces = netifaces.interfaces()
@@ -72,15 +75,20 @@ class Bigtop(object):
                 except KeyError:
                     continue
 
-                if ipaddress.ip_address(ip) in ipaddress.ip_network(network_interface):
+                if ipaddress.ip_address(ip) in ipaddress.ip_network(
+                        network_interface):
                     return ip
 
-            raise BigtopError(u"This machine has no interfaces in CIDR range {}".format(network_interface))
+            raise BigtopError(
+                u"This machine has no interfaces in CIDR range {}".format(
+                    network_interface))
         else:
             try:
                 ip = netifaces.ifaddresses(network_interface)[2][0]['addr']
             except ValueError:
-                raise BigtopError(u"This machine does not have an interface '{}'".format(network_interface))
+                raise BigtopError(
+                    u"This machine does not have an interface '{}'".format(
+                        network_interface))
             return ip
 
     def install(self):

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -53,8 +53,8 @@ class Bigtop(object):
 
         @param str network_interface: either the name of the
         interface, or a CIDR range, in which we expect the interface's
-        ip to fall. Also accepts 0.0.0.0 as a special case, which will
-        simply return 0.0.0.0.
+        ip to fall. Also accepts 0.0.0.0 (and variants, like 0/0) as a
+        special case, which will simply return what you passed in.
 
         """
         if network_interface.startswith('0') or network_interface == '::':

--- a/tests/unit/test_bigtop.py
+++ b/tests/unit/test_bigtop.py
@@ -318,6 +318,11 @@ class TestBigtopUnit(BigtopHarness):
         ip = self.bigtop.get_ip_for_interface('127.0.0.0/24')
         self.assertEqual(ip, '127.0.0.1')
 
+        # If passed 0.0.0.0, the function should treat it as a special
+        # case, and return what it was passed.
+        ip = self.bigtop.get_ip_for_interface('0.0.0.0')
+        self.assertEqual(ip, '0.0.0.0')
+
         self.assertRaises(
             BigtopError,
             self.bigtop.get_ip_for_interface,

--- a/tests/unit/test_bigtop.py
+++ b/tests/unit/test_bigtop.py
@@ -318,10 +318,11 @@ class TestBigtopUnit(BigtopHarness):
         ip = self.bigtop.get_ip_for_interface('127.0.0.0/24')
         self.assertEqual(ip, '127.0.0.1')
 
-        # If passed 0.0.0.0, the function should treat it as a special
-        # case, and return what it was passed.
-        ip = self.bigtop.get_ip_for_interface('0.0.0.0')
-        self.assertEqual(ip, '0.0.0.0')
+        # If passed 0.0.0.0, or something similar, the function should
+        # treat it as a special case, and return what it was passed.
+        for i in ['0.0.0.0', '0.0.0.0/0', '0/0', '::']:
+            ip = self.bigtop.get_ip_for_interface(i)
+            self.assertEqual(ip, i)
 
         self.assertRaises(
             BigtopError,


### PR DESCRIPTION
If someone passes 0.0.0.0 to get_ip_for_interface, the function will
return 0.0.0.0, which will then typically get written to a config,
allowing us to reset the software to listening on any interface.

@juju-solutions/bigdata 