### PR TITLE
By default apache-bigtop-base installs Java.

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -15,6 +15,11 @@ options:
     puppet-version: '3'
     silent: True
 defines:
+  install_java:
+    type: string
+    default: 'openjdk-8-jdk'
+    description: Tell this charm to install java, instead of relying on the openjdk charm. This string should match the name of the java package to be installed.
+
   bigtop_component_list:
     # XXX this should be a proper array of strings
     type: string

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -17,6 +17,7 @@ from jujubigdata import utils
 from charmhelpers.core import hookenv, unitdata
 from charmhelpers.core.host import chdir, chownr
 from charms.reactive import when, set_state, remove_state, is_state
+from charms.reactive.helpers import data_changed
 
 
 class BigtopError(Exception):
@@ -125,8 +126,11 @@ class Bigtop(object):
             fetch.apt_update()
         fetch.apt_install(java_package)
 
+        java_home_ = java_home()
+        data_changed('java_home', java_home_)  # Prime data changed
+
         utils.re_edit_in_place('/etc/environment', {
-            r'#? *JAVA_HOME *=.*': 'JAVA_HOME={}'.format(java_home()),
+            r'#? *JAVA_HOME *=.*': 'JAVA_HOME={}'.format(java_home_),
         }, append_non_matches=True)
 
     def pin_bigtop_packages(self):

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -15,7 +15,7 @@ from charmhelpers.fetch.archiveurl import ArchiveUrlFetchHandler
 from charmhelpers import fetch
 from jujubigdata import utils
 from charmhelpers.core import hookenv, unitdata
-from charmhelpers.core.host import chdir, chownr
+from charmhelpers.core.host import chdir, chownr, lsb_release
 from charms.reactive import when, set_state, remove_state, is_state
 from charms.reactive.helpers import data_changed
 
@@ -119,8 +119,7 @@ class Bigtop(object):
             # noop if we are setting up the openjdk relation.
             return
 
-        _, _, series = platform.dist()
-        if series == 'trusty':
+        if lsb_release()['DISTRIB_CODENAME'] == 'trusty':
             # No Java 8 on trusty
             fetch.add_source("ppa:openjdk-r/ppa")
             fetch.apt_update()

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -1,5 +1,4 @@
 import os
-import platform
 import socket
 import subprocess
 import yaml

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import socket
 import subprocess
 import yaml
@@ -117,8 +118,11 @@ class Bigtop(object):
             # noop if we are setting up the openjdk relation.
             return
 
-        fetch.add_source("ppa:openjdk-r/ppa")
-        fetch.apt_update()
+        _, _, series = platform.dist()
+        if series == 'trusty':
+            # No Java 8 on trusty
+            fetch.add_source("ppa:openjdk-r/ppa")
+            fetch.apt_update()
         fetch.apt_install(java_package)
 
         utils.re_edit_in_place('/etc/environment', {

--- a/reactive/apache_bigtop_base.py
+++ b/reactive/apache_bigtop_base.py
@@ -53,4 +53,4 @@ def set_java_home():
         # version of Java, set a flag that a layer can use to trigger
         # a restart of those services.
         if is_state('bigtop.available'):
-            set_state('java.changed')
+            set_state('bigtop.java.changed')

--- a/reactive/apache_bigtop_base.py
+++ b/reactive/apache_bigtop_base.py
@@ -4,6 +4,7 @@ from charms.reactive.helpers import data_changed, any_states
 from charmhelpers.core import hookenv, unitdata
 from charmhelpers.core.host import ChecksumError
 from charmhelpers.fetch import UnhandledSource
+from charms import layer
 from charms.layer.apache_bigtop_base import Bigtop
 from jujubigdata import utils
 
@@ -11,14 +12,16 @@ from jujubigdata import utils
 @when('puppet.available')
 @when_none('java.ready', 'hadoop-plugin.java.ready', 'hadoop-rest.joined')
 def missing_java():
-    if any_states('java.joined', 'hadoop-plugin.joined'):
+    if layer.options('apache-bigtop-base').get('install_java'):
+        set_state('install_java')
+    elif any_states('java.joined', 'hadoop-plugin.joined'):
         hookenv.status_set('waiting', 'waiting on java')
     else:
         hookenv.status_set('blocked', 'waiting on relation to java')
 
 
 @when('puppet.available')
-@when_any('java.ready', 'hadoop-plugin.java.ready')
+@when_any('java.ready', 'hadoop-plugin.java.ready', 'install_java')
 @when_not('bigtop.available')
 def fetch_bigtop():
     try:

--- a/reactive/apache_bigtop_base.py
+++ b/reactive/apache_bigtop_base.py
@@ -1,5 +1,5 @@
 from charms.reactive import when, when_any, when_not, when_none
-from charms.reactive import RelationBase, set_state
+from charms.reactive import RelationBase, set_state, is_state
 from charms.reactive.helpers import data_changed, any_states
 from charmhelpers.core import hookenv, unitdata
 from charmhelpers.core.host import ChecksumError
@@ -48,3 +48,9 @@ def set_java_home():
         utils.re_edit_in_place('/etc/environment', {
             r'#? *JAVA_HOME *=.*': 'JAVA_HOME={}'.format(java_home),
         }, append_non_matches=True)
+
+        # If we've potentially setup services with the previous
+        # version of Java, set a flag that a layer can use to trigger
+        # a restart of those services.
+        if is_state('bigtop.available'):
+            set_state('java.changed')

--- a/tests/unit/bigtop_harness.py
+++ b/tests/unit/bigtop_harness.py
@@ -1,48 +1,98 @@
-from path import Path
+#
+# bigtop_harness.py -- Harness for out unit tests
+#
+
+import logging
 import mock
 import os
-import sys
 import unittest
+from path import Path
+
+LOGGER = logging.getLogger()
+LOGGER.addHandler(logging.StreamHandler())
+LOGGER.setLevel(logging.DEBUG)
 
 
-class BigtopHarness(unittest.TestCase):
-    modules_to_mock = [
-        'charms.layer.apache_bigtop_base.layer',
-        'apache_bigtop_base.hookenv'
-    ]
+class Harness(unittest.TestCase):
+    '''
+    Harness for our unit tests. Automatically patches out options, and
+    sets up hooks to make patching out hookenv.status_get easier.
 
-    def setUp(self):
-        '''Mock out many things.'''
-        self.patchers = []
-        self.mocks = {}
+    '''
 
-        for module in self.modules_to_mock:
-            patcher = mock.patch(module)
-            self.mocks[module] = patcher.start()
-            self.patchers.append(patcher)
+    #
+    # Status related stuff
+    #
 
-        # Setup status list
-        self.statuses = []
-        mock_status = self.mocks['apache_bigtop_base.hookenv']
-        mock_status.status_set = lambda a, b: self.statuses.append((a,b))
-
-    def tearDown(self):
-        for patcher in self.patchers:
-            patcher.stop()
+    @property
+    def statuses(self):
+        if not hasattr(self, '_statuses'):
+            self._statuses = []
+        return self._statuses
 
     @property
     def last_status(self):
-        '''Helper for mocked out status list.'''
+        '''
+        Helper for mocked out status list.
 
+        Returns the last status set, or a (None, None) tuple if no
+        status has been set.
+
+        '''
+        if not self.statuses:
+            return (None, None)
         return self.statuses[-1]
 
-    @classmethod
-    def tearDownClass(cls):
+    def status_set(self, status, message):
+        '''Set our mock status.'''
+
+        self.statuses.append((status, message))
+
+
+    #
+    # Misc Helpers
+    #
+
+    def log(self, msg):
         '''
-        We don't mock out some calls that write to the unit state
-        db. Clean up that file here.
+        Print a given message to STDOUT.
 
         '''
+        self._log.debug(msg)
+
+
+    #
+    # init, setUp, tearDown
+    #
+
+    def __init__(self, *args, **kwargs):
+        unittest.TestCase.__init__(self, *args, **kwargs)
+
+        self._log = LOGGER
+
+    def setUp(self):
+        '''
+        Give each test access to a clean set of mocks.
+
+        '''
+        self._patchers = []
+
+        # Patch out options
+        self._patchers.append(mock.patch(
+            'apache_bigtop_base.layer.options', create=True))
+        self._patchers.append(mock.patch(
+            'charms.layer.apache_bigtop_base.layer.options', create=True))
+
+        for patcher in self._patchers:
+            patcher.start()
+
+    def tearDown(self):
+        '''Clean up our mocks.'''
+
+        for patcher in self._patchers:
+            patcher.stop()
+
+        # Clean up state db
         cwd = os.getcwd()
         state_db = Path(cwd) / '.unit-state.db'
         if state_db.exists():

--- a/tests/unit/test_bigtop.py
+++ b/tests/unit/test_bigtop.py
@@ -3,15 +3,21 @@ from path import Path
 import mock
 import unittest
 
-from bigtop_harness import BigtopHarness
+from bigtop_harness import Harness
 from charmhelpers.core import hookenv, unitdata
 from charms.reactive import set_state, is_state, remove_state
 
 from charms.layer.apache_bigtop_base import (
-    Bigtop, get_hadoop_version, get_layer_opts, get_fqdn, BigtopError)
+    Bigtop,
+    get_hadoop_version,
+    get_layer_opts,
+    get_fqdn,
+    BigtopError,
+    java_home
+)
 
 
-class TestBigtopUnit(BigtopHarness):
+class TestBigtopUnit(Harness):
     '''
     Unit tests for Bigtop class.
 
@@ -39,6 +45,33 @@ class TestBigtopUnit(BigtopHarness):
 
         '''
 
+    @mock.patch('charms.layer.apache_bigtop_base.utils')
+    @mock.patch('charms.layer.apache_bigtop_base.fetch')
+    @mock.patch('charms.layer.apache_bigtop_base.layer.options')
+    def test_install_java(self, mock_options, mock_fetch, mock_utils):
+        '''
+        Test to verify that we install java when requested.
+
+        '''
+        # Should be noop if bigtop_jdk not set.
+        self.bigtop.options.get.return_value = ''
+        self.bigtop.install_java()
+
+        self.assertFalse(mock_fetch.add_source.called)
+        self.assertFalse(mock_fetch.apt_update.called)
+        self.assertFalse(mock_fetch.apt_install.called)
+        self.assertFalse(mock_utils.re_edit_in_place.called)
+
+        # Should add ppa if we have set bigtop_jdk.
+        self.bigtop.options.get.return_value = 'foo'
+        print("options: {}".format(self.bigtop.options))
+        self.bigtop.install_java()
+
+        self.assertTrue(mock_fetch.add_source.called)
+        self.assertTrue(mock_fetch.apt_update.called)
+        self.assertTrue(mock_fetch.apt_install.called)
+        self.assertTrue(mock_utils.re_edit_in_place.called)
+
     @mock.patch('charms.layer.apache_bigtop_base.socket')
     @mock.patch('charms.layer.apache_bigtop_base.utils')
     @mock.patch('charms.layer.apache_bigtop_base.hookenv')
@@ -55,7 +88,6 @@ class TestBigtopUnit(BigtopHarness):
         # Test the case where we get an exception.
         class MockHError(Exception): pass
         def raise_herror(*args, **kwargs):
-            print('raising error!')
             raise MockHError('test')
         mock_socket.herror = MockHError
         mock_socket.gethostbyaddr = raise_herror
@@ -273,13 +305,15 @@ class TestBigtopUnit(BigtopHarness):
     @mock.patch('charms.layer.apache_bigtop_base.utils.run_as')
     @mock.patch('charms.layer.apache_bigtop_base.chdir')
     @mock.patch('charms.layer.apache_bigtop_base.chownr')
-    def test_run_smoke_tests(self, mock_ownr, mock_chdir, mock_run,
+    @mock.patch('charms.layer.apache_bigtop_base.layer.options')
+    def test_run_smoke_tests(self, mock_options, mock_ownr, mock_chdir, mock_run,
                              mock_sub):
         '''
         Verify that we attempt to run smoke tests correctly, and handle
         exceptions as expected.
 
         '''
+        mock_options.return_value = {}
         # Returns None if bigtop isn't available.
         remove_state('bigtop.available')
         self.assertEqual(None, self.bigtop.run_smoke_tests())
@@ -343,7 +377,7 @@ class TestBigtopUnit(BigtopHarness):
         # self.assertEqual(ip, '192.168.1.238')
 
 
-class TestHelpers(BigtopHarness):
+class TestHelpers(Harness):
 
     @unittest.skip('noop')
     def test_get_hadoop_version(self):
@@ -353,8 +387,9 @@ class TestHelpers(BigtopHarness):
     def test_get_layer_opts(self, mock_options):
         '''Verify that we parse whatever dict we get back from options.'''
 
-        ret = mock_options.return_value = {'foo': 'bar'}
-        self.assertEqual(ret['foo'], 'bar')
+        mock_options.return_value = {'foo': 'bar'}
+        ret = get_layer_opts()
+        self.assertEqual(ret.dist_config['foo'], 'bar')
 
     @mock.patch('charms.layer.apache_bigtop_base.subprocess')
     def test_get_fqdn(self, mock_sub):
@@ -374,3 +409,44 @@ class TestHelpers(BigtopHarness):
                 'foo'.encode('utf-8'),]:
             mock_sub.check_output.return_value = s
             self.assertEqual(get_fqdn(), 'foo')
+
+class TestJavaHome(Harness):
+
+    @mock.patch('charms.layer.apache_bigtop_base.unitdata.kv')
+    def test_java_home_default(self, mock_unitdata):
+        '''
+        Verify that we do the right thing when java home is set in a
+        relation.
+
+        '''
+        mock_unitdata.return_value = {'java_home': 'foo'}
+
+        self.assertEqual(java_home(), 'foo')
+
+    @mock.patch('charms.layer.apache_bigtop_base.unitdata.kv')
+    @mock.patch('charms.layer.apache_bigtop_base.layer.options')
+    def test_java_home_none(self, mock_options, mock_unitdata):
+        '''
+        Verify that we handle the situation where we have no java home.
+
+        '''
+        mock_unitdata.return_value = {}
+        mock_options.return_value = {}
+
+        self.assertEqual(java_home(), None)
+
+    @mock.patch('charms.layer.apache_bigtop_base.os.path')
+    @mock.patch('charms.layer.apache_bigtop_base.unitdata.kv')
+    @mock.patch('charms.layer.apache_bigtop_base.layer.options')
+    def test_java_home_options(self, mock_options, mock_unitdata, mock_path):
+        '''
+        Verify that we do the right thing when bigtop_jdk is set in
+        options.
+
+        '''
+        mock_unitdata.return_value = {}
+        mock_options.return_value = {'install_java': 'foo'}
+        mock_path.exists.return_value = True
+        mock_path.realpath.return_value = '/foo/bar/bin/java'
+
+        self.assertEqual('/foo/bar', java_home())

--- a/tests/unit/test_bigtop.py
+++ b/tests/unit/test_bigtop.py
@@ -45,17 +45,17 @@ class TestBigtopUnit(Harness):
 
         '''
 
-    @mock.patch('charms.layer.apache_bigtop_base.platform.dist')
+    @mock.patch('charms.layer.apache_bigtop_base.lsb_release')
     @mock.patch('charms.layer.apache_bigtop_base.utils')
     @mock.patch('charms.layer.apache_bigtop_base.fetch')
     @mock.patch('charms.layer.apache_bigtop_base.layer.options')
     def test_install_java(self, mock_options, mock_fetch,
-                          mock_utils, mock_dist):
+                          mock_utils, mock_lsb_release):
         '''
         Test to verify that we install java when requested.
 
         '''
-        mock_dist.return_value = ('Ubuntu', '16.04', 'xenial')
+        mock_lsb_release.return_value = {'DISTRIB_CODENAME': 'xenial'}
 
         # Should be noop if bigtop_jdk not set.
         self.bigtop.options.get.return_value = ''
@@ -77,7 +77,7 @@ class TestBigtopUnit(Harness):
         self.assertTrue(mock_utils.re_edit_in_place.called)
 
         # On trusty, should add a ppa so that we can install Java 8.
-        mock_dist.return_value = ('Ubuntu', '14.04', 'trusty')
+        mock_lsb_release.return_value = {'DISTRIB_CODENAME': 'trusty'}
         self.bigtop.install_java()
         self.assertTrue(mock_fetch.add_source.called)
         self.assertTrue(mock_fetch.apt_update.called)
@@ -317,8 +317,8 @@ class TestBigtopUnit(Harness):
     @mock.patch('charms.layer.apache_bigtop_base.chdir')
     @mock.patch('charms.layer.apache_bigtop_base.chownr')
     @mock.patch('charms.layer.apache_bigtop_base.layer.options')
-    def test_run_smoke_tests(self, mock_options, mock_ownr, mock_chdir, mock_run,
-                             mock_sub):
+    def test_run_smoke_tests(self, mock_options, mock_ownr, mock_chdir,
+                             mock_run, mock_sub):
         '''
         Verify that we attempt to run smoke tests correctly, and handle
         exceptions as expected.

--- a/tests/unit/test_reactive_handlers.py
+++ b/tests/unit/test_reactive_handlers.py
@@ -124,14 +124,14 @@ class TestJavaHome(Harness):
         self.assertTrue(mock_utils.re_edit_in_place.called)
 
 
-        # Verify that we set the java.changed flag when appropriate.
+        # Verify that we set the bigtop.java.changed flag when appropriate.
 
         # Bigtop is available, but java home not changed
         set_state('bigtop.available')
         set_java_home()
-        self.assertFalse(is_state('java.changed'))
+        self.assertFalse(is_state('bigtop.java.changed'))
 
         # Bigtop is available, and java home has changed
         mock_java.java_home.return_value = 'qux'
         set_java_home()
-        self.assertTrue(is_state('java.changed'))
+        self.assertTrue(is_state('bigtop.java.changed'))

--- a/tests/unit/test_reactive_handlers.py
+++ b/tests/unit/test_reactive_handlers.py
@@ -106,6 +106,8 @@ class TestJavaHome(Harness):
         mock_java.java_home.return_value = 'foo'
         mock_java.java_version.return_value = 'bar'
         mock_relation_base.from_state.return_value = mock_java
+        remove_state('bigtop.available')    # This might have been set
+                                            # by previous tests.
 
         data_changed('java_home', 'foo')  # Prime data changed
 
@@ -120,3 +122,16 @@ class TestJavaHome(Harness):
         set_java_home()
 
         self.assertTrue(mock_utils.re_edit_in_place.called)
+
+
+        # Verify that we set the java.changed flag when appropriate.
+
+        # Bigtop is available, but java home not changed
+        set_state('bigtop.available')
+        set_java_home()
+        self.assertFalse(is_state('java.changed'))
+
+        # Bigtop is available, and java home has changed
+        mock_java.java_home.return_value = 'qux'
+        set_java_home()
+        self.assertTrue(is_state('java.changed'))

--- a/tests/unit/test_reactive_handlers.py
+++ b/tests/unit/test_reactive_handlers.py
@@ -8,21 +8,35 @@ from charms.reactive import set_state, remove_state, is_state
 from charms.reactive.bus import get_state
 from charms.reactive.helpers import data_changed
 
-from bigtop_harness import BigtopHarness
+from bigtop_harness import Harness
 
 from apache_bigtop_base import missing_java, fetch_bigtop, set_java_home
 
 
-class TestMissingJava(BigtopHarness):
+class TestMissingJava(Harness):
     '''tests for our missing_java reactive handler.'''
 
-    def test_missing_java(self):
+    @mock.patch('apache_bigtop_base.layer.options')
+    @mock.patch('apache_bigtop_base.hookenv.status_set')
+    def test_missing_java(self, mock_status, mock_options):
         '''
         Test to verify that our missing_java function kicks us into a
         'waiting' state if 'java.joined' is set, or tells us that
         we're blocked if it is not.
 
+        In the case of install_java being set, verify that we instead
+        set the install_java state, and set no status.
+
         '''
+        mock_status.side_effect = self.status_set
+        mock_options.return_value = {'install_java': 'foo'}
+
+        missing_java()
+        self.assertTrue(is_state('install_java'))
+        self.assertFalse(self.last_status[0])
+
+        mock_options.return_value = {'install_java': ''}
+
         set_state('some.state')
         missing_java()
         self.assertEqual(self.last_status[0], 'blocked')
@@ -35,8 +49,7 @@ class TestMissingJava(BigtopHarness):
         missing_java()
         self.assertEqual(self.last_status[0], 'blocked')
 
-
-class TestFetchBigtop(BigtopHarness):
+class TestFetchBigtop(Harness):
     '''
     Test the fetch_bigtop reactive handler.
 
@@ -56,7 +69,9 @@ class TestFetchBigtop(BigtopHarness):
         fetch_bigtop()
         self.assertTrue(is_state('bigtop.available'))
 
-    def test_fetch_bigtop_unhandled_source(self):
+    @mock.patch('apache_bigtop_base.hookenv.status_set')
+    def test_fetch_bigtop_unhandled_source(self, mock_status):
+        mock_status.side_effect = self.status_set
         def raise_unhandled(*args, **kwargs):
             raise UnhandledSource('test')
         self.mock_bigtop.install.side_effect = raise_unhandled
@@ -64,15 +79,9 @@ class TestFetchBigtop(BigtopHarness):
 
         self.assertEqual(self.last_status[0], 'blocked')
 
-    def test_fetch_bigtop_unhandled_source(self):
-        def raise_unhandled(*args, **kwargs):
-            raise UnhandledSource('test')
-        self.mock_bigtop.install.side_effect = raise_unhandled
-        fetch_bigtop()
-
-        self.assertEqual(self.last_status[0], 'blocked')
-
-    def test_fetch_bigtop_checksum_error(self):
+    @mock.patch('apache_bigtop_base.hookenv.status_set')
+    def test_fetch_bigtop_checksum_error(self, mock_status):
+        mock_status.side_effect = self.status_set
         def raise_checksum(*args, **kwargs):
             raise ChecksumError('test')
 
@@ -82,7 +91,7 @@ class TestFetchBigtop(BigtopHarness):
         self.assertEqual(self.last_status[0], 'waiting')
         self.assertTrue('checksum error' in self.last_status[1])
 
-class TestJavaHome(BigtopHarness):
+class TestJavaHome(Harness):
     '''Tests for our set_java_home reactive handler.'''
 
     @mock.patch('apache_bigtop_base.utils')


### PR DESCRIPTION
This eliminates the need for the openjdk relation, which makes
Zookeeper more backwards compatible, and simplifies everything else.

@juju-solutions/bigdata 