### PR TITLE
replace smoke test config files with env

### DIFF
--- a/actions/smoke-test
+++ b/actions/smoke-test
@@ -32,8 +32,9 @@ from charms.layer.apache_bigtop_base import Bigtop
 from charms.reactive import is_state
 
 
-def fail(msg, output):
-    hookenv.action_set({'output': output})
+def fail(msg, output=None):
+    if output:
+        hookenv.action_set({'output': output})
     hookenv.action_fail(msg)
     sys.exit()
 
@@ -42,13 +43,12 @@ if not is_state('bigtop.available'):
 
 cfg = layer.options('apache-bigtop-base')
 smoke_components = cfg.get('bigtop_smoketest_components')
-smoke_configs = cfg.get('bigtop_smoketest_configs')
 if not smoke_components:
     fail('No bigtop_smoketest_components found for this charm')
 
 bigtop = Bigtop()
-result = bigtop.run_smoke_tests(smoke_components, smoke_configs)
+result = bigtop.run_smoke_tests(smoke_components)
 if result == 'success':
     hookenv.action_set({'outcome': result})
 else:
-    fail('failed smoke testing: %s' % smoke_components, result)
+    fail('failed smoke testing {}'.format(smoke_components), result)

--- a/layer.yaml
+++ b/layer.yaml
@@ -73,14 +73,6 @@ defines:
         smoke-test action. Available components can be found at:
         https://github.com/apache/bigtop/tree/master/bigtop-tests/smoke-tests
 
-  bigtop_smoketest_configs:
-    type: array
-    items: {type: string}
-    description: |
-        A list of files containing environment configuration required by
-        the Bigtop smoke tests configured above. For example,
-        '- /etc/default/hadoop'.
-
   groups:
     description: |
       A list of system groups to be created during setup.


### PR DESCRIPTION
We currently allow charms to specify a smoke_test_configs layer opt,
which is supposed to be files that we source prior to running the
smoke test. This is hard to handle because we don't know if that
file will be an ini, a dotfile, or some other thing that we have to
grok and source.

Seems smarter for the smoke test itself to construct a dict of all
the environment stuff it needs and pass that into the smoke test
runner.

This does that. I do not believe anyone is using the config file
madness, and it certainly didn't do anything in the smoke test
runner function, so I feel like now's the time to get on the right
path.