### PR TITLE
add pkg version method (and unit tests)

### DIFF
--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -491,16 +491,16 @@ def get_hadoop_version():
     return parts[1]
 
 
-def get_package_version(pkg=None):
+def get_package_version(pkg):
     """
     Return a version string for a given package name.
 
     :param: str pkg: package name as known by the package manager
     :returns: version string or None
     """
-    ver_str = None
     if pkg:
         distro = lsb_release()['DISTRIB_ID'].lower()
+        ver_str = None
         if distro == 'ubuntu':
             # NB: we cannot use the charmhelpers.fetch.apt_cache nor the
             # apt module from the python3-apt deb as they are only available
@@ -513,7 +513,9 @@ def get_package_version(pkg=None):
                 hookenv.log(
                     'Error getting package version: {}'.format(e.output),
                     hookenv.ERROR)
-    return ver_str
+        return ver_str
+    else:
+        raise BigtopError(u"Valid package name required")
 
 
 def java_home():

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -496,11 +496,11 @@ def get_package_version(pkg):
     Return a version string for a given package name.
 
     :param: str pkg: package name as known by the package manager
-    :returns: version string or None
+    :returns: str ver_str: version string from package manager, or empty string
     """
     if pkg:
         distro = lsb_release()['DISTRIB_ID'].lower()
-        ver_str = None
+        ver_str = ''
         if distro == 'ubuntu':
             # NB: we cannot use the charmhelpers.fetch.apt_cache nor the
             # apt module from the python3-apt deb as they are only available

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -491,6 +491,31 @@ def get_hadoop_version():
     return parts[1]
 
 
+def get_package_version(pkg=None):
+    """
+    Return a version string for a given package name.
+
+    :param: str pkg: package name as known by the package manager
+    :returns: version string or None
+    """
+    ver_str = None
+    if pkg:
+        distro = lsb_release()['DISTRIB_ID'].lower()
+        if distro == 'ubuntu':
+            # NB: we cannot use the charmhelpers.fetch.apt_cache nor the
+            # apt module from the python3-apt deb as they are only available
+            # as system packages. Any charm with use_system_packages=False in
+            # layer.yaml would fail. Use dpkg-query instead.
+            cmd = ['dpkg-query', '--show', r'--showformat=${Version}', pkg]
+            try:
+                ver_str = subprocess.check_output(cmd).strip().decode()
+            except subprocess.CalledProcessError as e:
+                hookenv.log(
+                    'Error getting package version: {}'.format(e.output),
+                    hookenv.ERROR)
+    return ver_str
+
+
 def java_home():
     '''Figure out where Java lives.'''
 

--- a/tests/unit/test_bigtop.py
+++ b/tests/unit/test_bigtop.py
@@ -429,7 +429,7 @@ class TestHelpers(Harness):
             raise MockException('foo!')
         mock_sub.check_output.side_effect = mock_raise
 
-        self.assertEqual(get_package_version('foo'), None)
+        self.assertEqual(get_package_version('foo'), '')
 
     @mock.patch('charms.layer.apache_bigtop_base.layer.options')
     def test_get_layer_opts(self, mock_options):

--- a/tests/unit/test_bigtop.py
+++ b/tests/unit/test_bigtop.py
@@ -8,6 +8,7 @@ from charmhelpers.core import unitdata
 from charms.reactive import set_state, is_state, remove_state
 
 from charms.layer.apache_bigtop_base import (
+    BigtopError,
     Bigtop,
     get_layer_opts,
     get_fqdn,
@@ -410,9 +411,15 @@ class TestHelpers(Harness):
     @mock.patch('charms.layer.apache_bigtop_base.subprocess')
     def test_get_package_version(self, mock_sub):
         '''Verify expected package version is returned.'''
+        # test empty package name
+        with self.assertRaises(BigtopError):
+            get_package_version('')
+
+        # test good check_output result
         mock_sub.check_output.return_value = b'1.2.3'
         self.assertEqual(get_package_version('foo'), '1.2.3')
 
+        # test bad check_output result
         class MockException(Exception):
             pass
         MockException.output = "package foo not found"


### PR DESCRIPTION
Add helper to return a version string given a package name (currently, only dpkg is supported).  This is useful for `hookenv.application_version_set` when we only have the package manager to rely on.