### PR TITLE
treat dphys-swapfile more especialer

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -8,7 +8,6 @@ ignore:
 options:
   basic:
     packages:
-      - dphys-swapfile
       - puppet-common
       - unzip
 defines:

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -144,7 +144,6 @@ class Bigtop(object):
             hookenv.log('Could not inspect /proc/swaps: {}'.format(e),
                         hookenv.INFO)
             swap_out = None
-            pass
         lines = swap_out.splitlines() if swap_out else []
         if len(lines) < 2:
             # /proc/swaps has a header row; if we dont have at least 2 lines,
@@ -156,7 +155,6 @@ class Bigtop(object):
                 hookenv.log('Proceeding with no swap due to an error '
                             'installing dphys-swapfile: {}'.format(e),
                             hookenv.ERROR)
-                pass
 
             # Always include dphys-swapfile status in the log
             cmd = ['systemctl', 'status', 'dphys-swapfile.service']

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -15,7 +15,7 @@ from charmhelpers.fetch.archiveurl import ArchiveUrlFetchHandler
 from charmhelpers import fetch
 from jujubigdata import utils
 from charmhelpers.core import hookenv, unitdata
-from charmhelpers.core.host import chdir, chownr, lsb_release
+from charmhelpers.core.host import chdir, chownr, init_is_systemd, lsb_release
 from charms.reactive import when, set_state, remove_state, is_state
 from charms.reactive.helpers import data_changed
 
@@ -157,7 +157,10 @@ class Bigtop(object):
                             hookenv.ERROR)
 
             # Always include dphys-swapfile status in the log
-            cmd = ['systemctl', 'status', 'dphys-swapfile.service']
+            if init_is_systemd():
+                cmd = ['systemctl', 'status', 'dphys-swapfile.service']
+            else:
+                cmd = ['service', 'dphys-swapfile', 'status']
             try:
                 systemd_out = subprocess.check_output(cmd)
             except subprocess.CalledProcessError as e:

--- a/tests/unit/test_bigtop.py
+++ b/tests/unit/test_bigtop.py
@@ -14,7 +14,6 @@ from charms.layer.apache_bigtop_base import (
     get_fqdn,
     get_package_version,
     is_localdomain,
-    BigtopError,
     java_home
 )
 
@@ -46,6 +45,10 @@ class TestBigtopUnit(Harness):
         integration tests.
 
         '''
+
+    @unittest.skip('noop')
+    def test_install_swap(self):
+        '''Mainly system calls -- covered by linter and basic deploy tests.'''
 
     @mock.patch('charms.layer.apache_bigtop_base.lsb_release')
     @mock.patch('charms.layer.apache_bigtop_base.utils')


### PR DESCRIPTION
dphys-swapfile is special. On initial service start, it generates a file
to use as swap. This can take a long time, and on very slow/busy disks,
it will cause a systemd timeout (systemd gives services 60s to come up by
default).

We've seen cwr failures related to dphys-swapfile.service not starting,
which fails our runs. Let's do a few things:

- if the system already has swap, don't install dphys-swapfile
- if the package fails to install, inform the user (but since this isn't
a required package for bigtop, don't fail)
- if the service fails to start, inform the user why (again, since it's
optional, don't fail in this scenario either)