### PR TITLE
support installing from bigtop-master

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -8,6 +8,7 @@ ignore:
 options:
   basic:
     packages:
+      - git
       - puppet-common
       - unzip
 defines:
@@ -28,41 +29,10 @@ defines:
     type: string
     default: '1.1.0'
     description: |
-        Bigtop release version. Affects the location of Hiera bits, Puppet
-        recipes, and repository used for installing packages.
-
-  bigtop_release_url:
-    type: string
-    default: 'https://www.apache.org/dist/bigtop/bigtop-1.1.0/bigtop-1.1.0-project.tar.gz?sha1=abeb9fec87f3923948e506e37a196bc490512eba'
-    description: |
-        URL to the location of Bigtop source tarball v.1.1.0
-        This points to the official Apache Bigtop releases on of the ASF mirrors.
-        The source code is needed in order to get access to project's Puppet recipes
-
-  bigtop_repo_url:
-    type: string
-    default: 'http://bigtop-repos.s3.amazonaws.com/releases/{version}/{dist}/{series}/{arch}'
-    description: |
-        Apache Bigtop repo URL used to install Bigtop packages. The version
-        dist, series, and arch will be substituted based on the platform and
-        configuration at deployment time. You may specify a URL that omits
-        these special keys; they will be ignored if not present during
-        substitution.
-
-  bigtop_global_hiera:
-    type: string
-    default: '/etc/puppet/hiera.yaml'
-    description: 'Hiera global configuration file'
-
-  bigtop_hiera_config:
-    type: string
-    default: 'bigtop-deploy/puppet/hiera.yaml'
-    description: 'Hiera Bigtop config file, relative to the bigtop src dir'
-
-  bigtop_hiera_siteyaml:
-    type: string
-    default: 'bigtop-deploy/puppet/hieradata/site.yaml'
-    description: 'Hiera Bigtop site yaml, relative to the bigotp src dir'
+        Apache Bigtop release version. The default, '1.1.0' will use the
+        current GA release, Bigtop 1.1.0, for all hiera data, puppet recipes,
+        and installable packages. Set this to 'master' to use the latest
+        upstream bits.
 
   bigtop_smoketest_components:
     type: array

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -1,5 +1,4 @@
 import os
-import platform
 import socket
 import subprocess
 import yaml
@@ -29,9 +28,19 @@ class Bigtop(object):
     _overrides = {}
 
     @property
+    def bigtop_apt(self):
+        '''URL of the bigtop apt repository.'''
+        return self._bigtop_apt
+
+    @property
     def bigtop_base(self):
         '''Path to the bigtop root directory.'''
         return self._bigtop_base
+
+    @property
+    def bigtop_version(self):
+        '''Bigtop version.'''
+        return self._bigtop_version
 
     @property
     def site_yaml(self):
@@ -41,49 +50,13 @@ class Bigtop(object):
     def __init__(self):
         self.bigtop_dir = '/home/ubuntu/bigtop.release'
         self.options = layer.options('apache-bigtop-base')
-        self.bigtop_version = self.options['bigtop_version']
+        self._bigtop_apt = None
+        self._bigtop_version = self.options.get('bigtop_version')
         self._bigtop_base = Path(self.bigtop_dir) / 'bigtop-{}'.format(
             self.bigtop_version)
         self._site_yaml = (
             Path(self.bigtop_base) / 'bigtop-deploy/puppet/hieradata/site.yaml'
         )
-
-        # pkg repo is dependent on the bigtop version and OS
-        dist_name, _, dist_series = platform.linux_distribution()
-        if self.bigtop_version == '1.1.0':
-            repo_url = ('http://bigtop-repos.s3.amazonaws.com/releases/'
-                        '{version}/{dist}/{series}/{arch}')
-            repo_arch = utils.cpu_arch()
-            if dist_name.lower() == 'ubuntu':
-                # NB: For 1.1.0, x86 must install from the trusty repo;
-                # ppc64le only works from vivid.
-                if repo_arch.lower() == "ppc64le":
-                    dist_series = "vivid"
-                    # 'le' and 'el' are swapped due to historical awfulness:
-                    #   https://lists.debian.org/debian-powerpc/2014/08/msg00042.html
-                    repo_arch = "ppc64el"
-                else:
-                    dist_series = "trusty"
-            # Substitute params. It's ok if any of these (version, dist,
-            # series, arch) are missing.
-            self.bigtop_apt = repo_url.format(
-                version=self.bigtop_version,
-                dist=dist_name.lower(),
-                series=dist_series.lower(),
-                arch=repo_arch
-            )
-        elif self.bigtop_version == 'master':
-            if dist_name.lower() == 'ubuntu' and dist_series.lower() == 'xenial':
-                self.bigtop_apt = ('http://ci.bigtop.apache.org:8080/'
-                                   'job/Bigtop-trunk-repos/'
-                                   'OS=ubuntu-16.04,label=docker-slave-06/'
-                                   'ws/output/apt')
-            else:
-                raise BigtopError(
-                    u"Charms only support Bigtop master on Ubuntu/Xenial.")
-        else:
-            raise BigtopError(
-                u"Unknown Bigtop version: {}".format(self.bigtop_version))
 
     def get_ip_for_interface(self, network_interface):
         """
@@ -137,6 +110,7 @@ class Bigtop(object):
         You will then need to call `render_site_yaml` to set up the correct
         configuration and `trigger_puppet` to install the desired components.
         """
+        self.configure_repo()
         self.install_swap()
         self.install_java()
         self.pin_bigtop_packages()
@@ -146,6 +120,55 @@ class Bigtop(object):
         self.install_puppet_modules()
         self.apply_patches()
         self.render_hiera_yaml()
+
+    def configure_repo(self):
+        """
+        Set our package repo based on the version layer opt.
+
+        The package repository is dependent on the bigtop version and
+        OS attributes. Construct an appropriate value to use as our site
+        bigtop::bigtop_repo_uri param.
+
+        Raise BigtopError if we have an unexpected version string.
+        """
+        release_info = lsb_release()
+        dist_name = release_info['DISTRIB_ID'].lower()
+        dist_series = release_info['DISTRIB_CODENAME'].lower()
+
+        if self.bigtop_version == '1.1.0':
+            repo_url = ('http://bigtop-repos.s3.amazonaws.com/releases/'
+                        '{version}/{dist}/{series}/{arch}')
+            repo_arch = utils.cpu_arch().lower()
+            if dist_name == 'ubuntu':
+                # NB: For 1.1.0, x86 must install from the trusty repo;
+                # ppc64le only works from vivid.
+                if repo_arch == "ppc64le":
+                    dist_series = "vivid"
+                    # 'le' and 'el' are swapped due to historical awfulness:
+                    #   https://lists.debian.org/debian-powerpc/2014/08/msg00042.html
+                    repo_arch = "ppc64el"
+                else:
+                    dist_series = "trusty"
+            # Substitute params. It's ok if any of these (version, dist,
+            # series, arch) are missing.
+            self._bigtop_apt = repo_url.format(
+                version=self.bigtop_version,
+                dist=dist_name.lower(),
+                series=dist_series.lower(),
+                arch=repo_arch
+            )
+        elif self.bigtop_version == 'master':
+            if dist_name == 'ubuntu' and dist_series == 'xenial':
+                self._bigtop_apt = ('http://ci.bigtop.apache.org:8080/'
+                                    'job/Bigtop-trunk-repos/'
+                                    'OS=ubuntu-16.04,label=docker-slave-06/'
+                                    'ws/output/apt')
+            else:
+                raise BigtopError(
+                    u"Charms only support Bigtop master on Ubuntu/Xenial.")
+        else:
+            raise BigtopError(
+                u"Unknown Bigtop version: {}".format(self.bigtop_version))
 
     def install_swap(self):
         """
@@ -319,7 +342,8 @@ class Bigtop(object):
         Render the ``hiera.yaml`` file with the correct path to the bigtop
         ``site.yaml`` file.
         """
-        hiera_src = Path(self.bigtop_base) / 'bigtop-deploy/puppet/hiera.yaml'
+        bigtop_hiera = 'bigtop-deploy/puppet/hiera.yaml'
+        hiera_src = Path('{}/{}'.format(self.bigtop_base, bigtop_hiera))
         hiera_dst = Path('/etc/puppet/hiera.yaml')
 
         # read template defaults

--- a/tests/unit/test_bigtop.py
+++ b/tests/unit/test_bigtop.py
@@ -24,7 +24,10 @@ class TestBigtopUnit(Harness):
 
     '''
 
-    def setUp(self):
+    @mock.patch('charms.layer.apache_bigtop_base.Bigtop.bigtop_version',
+                new_callable=mock.PropertyMock)
+    def setUp(self, mock_ver):
+        mock_ver.return_value = 'master'
         super(TestBigtopUnit, self).setUp()
         self.bigtop = Bigtop()
 
@@ -49,10 +52,8 @@ class TestBigtopUnit(Harness):
     @mock.patch('charms.layer.apache_bigtop_base.utils')
     @mock.patch('charms.layer.apache_bigtop_base.layer.options')
     @mock.patch('charms.layer.apache_bigtop_base.lsb_release')
-    @mock.patch('charms.layer.apache_bigtop_base.Bigtop.bigtop_version',
-                new_callable=mock.PropertyMock)
-    def test_configure_repo(self, mock_ver, mock_lsb_release,
-                            mock_options, mock_utils):
+    def test_get_repo_url(self, mock_lsb_release,
+                          mock_options, mock_utils):
         '''
         Test to verify that we setup an appropriate repository.
 
@@ -60,31 +61,29 @@ class TestBigtopUnit(Harness):
         # master on xenial should not construct a url with cpu_arch
         mock_lsb_release.return_value = {'DISTRIB_CODENAME': 'xenial',
                                          'DISTRIB_ID': 'ubuntu'}
-        mock_ver.return_value = 'master'
-        self.bigtop.configure_repo()
+        self.bigtop.get_repo_url('master')
         self.assertFalse(mock_utils.cpu_arch.called)
 
         # master on trusty should throw an exception
         mock_lsb_release.return_value = {'DISTRIB_CODENAME': 'trusty',
                                          'DISTRIB_ID': 'ubuntu'}
-        mock_ver.return_value = 'master'
         self.assertRaises(
             BigtopError,
-            self.bigtop.configure_repo)
+            self.bigtop.get_repo_url,
+            'master')
 
         # master on non-ubuntu should throw an exception
         mock_lsb_release.return_value = {'DISTRIB_CODENAME': 'xenial',
                                          'DISTRIB_ID': 'centos'}
-        mock_ver.return_value = 'master'
         self.assertRaises(
             BigtopError,
-            self.bigtop.configure_repo)
+            self.bigtop.get_repo_url,
+            'master')
 
         # 1.1.0 on xenial should construct a repo using the cpu_arch
         mock_lsb_release.return_value = {'DISTRIB_CODENAME': 'xenial',
                                          'DISTRIB_ID': 'ubuntu'}
-        mock_ver.return_value = '1.1.0'
-        self.bigtop.configure_repo()
+        self.bigtop.get_repo_url('1.1.0')
         self.assertTrue(mock_utils.cpu_arch.called)
 
     @unittest.skip('noop')
@@ -301,13 +300,16 @@ class TestBigtopUnit(Harness):
         self.assertTrue(is_state('apache-bigtop-base.puppet_queued'))
 
     @mock.patch('charms.layer.apache_bigtop_base.Bigtop.trigger_puppet')
-    def test_handle_queued_puppet(self, mock_trigger):
+    @mock.patch('charms.layer.apache_bigtop_base.Bigtop.bigtop_version',
+                new_callable=mock.PropertyMock)
+    def test_handle_queued_puppet(self, mock_ver, mock_trigger):
         '''
         Verify that we attempt to call puppet when it has been queued, and
         then clear the queued state.
 
         '''
         set_state('apache-bigtop-base.puppet_queued')
+        mock_ver.return_value = 'master'
         Bigtop._handle_queued_puppet()
         self.assertTrue(mock_trigger.called)
         self.assertFalse(is_state('apache-bigtop-base.puppet_queued'))

--- a/tests/unit/test_bigtop.py
+++ b/tests/unit/test_bigtop.py
@@ -119,16 +119,12 @@ class TestBigtopUnit(Harness):
         self.bigtop.check_reverse_dns()
         self.assertFalse(unitdata.kv().get('reverse_dns_ok'))
 
-    @mock.patch('charms.layer.apache_bigtop_base.ArchiveUrlFetchHandler')
     def test_fetch_bigtop_release(self, mock_fetch):
-        '''Verify that we attemp to fetch and install the bigtop archive.'''
-
-        mock_au = mock.Mock()
-        mock_fetch.return_value = mock_au
-
-        self.bigtop.fetch_bigtop_release()
-
-        self.assertTrue(mock_au.install.called)
+        '''Verify we raise an exception if an invalid release is specified.'''
+        self.assertRaises(
+            BigtopError,
+            self.bigtop.fetch_bigtop_release,
+            '1.2')
 
     @mock.patch('charms.layer.apache_bigtop_base.utils')
     def test_install_puppet_modules(self, mock_utils):


### PR DESCRIPTION
Setup our release bits (hieradata and puppet recipes) and package
repository based on the bigtop_version layer option.

Currently only '1.1.0' and 'master' are supported. For 1.1.0, we
still have to construct a funky repo url since the repo only supports
trusty (x86) and vivid (ppc). For master, we'll pull packages straight
from the ci system.

While we're here, let's simplify the layer options. Given the version,
we can construct everything else we need:

- remove bigtop_release_url
We don't need the user to set a release tarball url since we can git
clone it based on the version branch. This will break in a restricted
env that cannot access github, but it would probably break anyway trying
to wget a blob from apache.org. The right way to handle restricted envs
is to use resources so we can fall back to a release package if git
cloning fails. This is on the roadmap for a future rev.

- remove bigtop_repo_url
As mentioned earlier, we can construct this for 1.1.0, and we have a
static repo url to use for master.

- remove bigtop_*hiera*:
There's no good reason to ever let someone change these as they are
baked all over the bigtop release source. If these need to be
customized, the user will need to do that in a forked bigtop release
repo that can be attached as a resource in the future (see above).