### PR TITLE
do not configure swap in containers

### DIFF
--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -17,7 +17,8 @@ from charmhelpers.core.host import (
     chownr,
     file_hash,
     init_is_systemd,
-    lsb_release
+    is_container,
+    lsb_release,
 )
 from charms.reactive import when, set_state, remove_state, is_state
 from charms.reactive.helpers import data_changed
@@ -191,7 +192,10 @@ class Bigtop(object):
         You will then need to call `render_site_yaml` to set up the correct
         configuration and `trigger_puppet` to install the desired components.
         """
-        self.install_swap()
+        if not is_container():
+            # Only configure swap in non-containerized envs. Containers inherit
+            # the host OS swap config.
+            self.install_swap()
         self.install_java()
         self.pin_bigtop_packages()
         self.check_localdomain()


### PR DESCRIPTION
On LXD, if we have a host OS with no swap configured, our charms will attempt to setup swap space inside the containers.  This is bad because the host OS will effectively have this space "swapped on", which will prevent us from being able to destroy these containers:

```
ERROR while removing instance "juju-cb95ef-2": error removing /var/snap/conjure-up/common/lxd/storage-pools/default/containers/juju-cb95ef-2: rm: cannot remove '/var/snap/conjure-up/common/lxd/storage-pools/default/containers/juju-cb95ef-2/rootfs/var/swap': Operation not permitted
```