### PR TITLE
support bigtop charm upgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ all: lint unit_test
 
 .PHONY: clean
 clean:
+	@rm -f .coverage
 	@rm -rf .tox
 
 .PHONY: apt_prereqs

--- a/README.md
+++ b/README.md
@@ -62,9 +62,13 @@ valid components][components].
 
 This layer will set the following states:
 
-  * *bigtop.available*: This state is set after `Bigtop.install` has
-      been run. At this point, you are free to invoke
-      `Bigtop.render_site_yaml`.
+  * *bigtop.available*: This state is set after `Bigtop.install` has been run.
+  At this point, you are free to invoke `Bigtop.render_site_yaml`.
+
+  * *bigtop.version.changed*: This state is set after a user has changed
+  the `bigtop_version` config option. At this point, your charm can call
+  `Bigtop.check_bigtop_repo_package` to determine if a new package version
+  is available. See the **Bigtop Versions** section for more details.
 
 ## Layer configuration
 
@@ -82,6 +86,17 @@ that hosts dict.
 
 ## Actions
 
+### reinstall ###
+This layer provides a generic `reinstall` action that will invoke
+`Bigtop.reinstall_repo_packages`. This is meant to serve as a template for
+writing a Bigtop charm-specific action used to upgrade packages when a new
+Bigtop repository has been configured. See the
+[Spark reinstall action][spark-reinstall] as an example of extending this
+generic action.
+
+[spark-reinstall]: https://github.com/apache/bigtop/blob/master/bigtop-packages/src/charm/spark/layer-spark/actions/reinstall
+
+### smoke-test ###
 This layer provides a generic `smoke-test` action that will invoke [Bigtop
 smoke tests][bigtop-smoke]. This is meant to serve as a template for
 writing a Bigtop charm-specific test. See the [Zookeeper smoke
@@ -103,6 +118,29 @@ juju deploy hadoop-namenode --resource bigtop-repo=/tmp/branch-1.1.zip
 ```
 
 [bigtop-repo]: https://github.com/apache/bigtop/tree/master
+
+## Bigtop Versions
+
+The `bigtop_version` config option can be used to change the version of
+Bigtop at runtime:
+
+    juju config <charm> bigtop_version=1.2.1
+
+When changed, this layer will configure a new repository, fetch the new bigtop
+source, patch it as needed, and set the `bigtop.version.changed` state. When
+this state is set, your charm may query package version changes using
+`Bigtop.check_bigtop_repo_package`. If a version has changed, your charm may
+then inform the user that an upgrade is available and direct them to use the
+`reinstall` action to upgrade each affected unit.
+
+If a user wishes to roll back to a previous Bigtop version, they simply
+re-configure `bigtop_version`:
+
+    juju config <charm> bigtop_version=1.2.0
+
+This layer does **not** perform any automatic upgrades. User intervention is
+always required by calling the `reinstall` action before bits are changed
+on disk.
 
 ## Unit Tests
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ consult [this list of valid roles][roles] to see what is available.
 
 [roles]: https://github.com/apache/bigtop/blob/master/bigtop-deploy/puppet/manifests/cluster.pp)
 
-**Note**: Bigtop is also able to generate a list of roles from a
+> **Note**: Bigtop is also able to generate a list of roles from a
 *component*. The Bigtop class is theoretically able to infer
 components from the *hosts* dict that you pass to
 `.render_site_yaml`. As of this writing, this code path is not well
@@ -65,9 +65,9 @@ This layer will set the following states:
   * *bigtop.available*: This state is set after `Bigtop.install` has been run.
   At this point, you are free to invoke `Bigtop.render_site_yaml`.
 
-  * *bigtop.version.changed*: This state is set after a user has changed
-  the `bigtop_version` config option. At this point, your charm can call
-  `Bigtop.check_bigtop_repo_package` to determine if a new package version
+  * *bigtop.version.changed*: (experimental) This state is set after a user has
+  changed the `bigtop_version` config option. At this point, your charm can
+  call `Bigtop.check_bigtop_repo_package` to determine if a new package version
   is available. See the **Bigtop Versions** section for more details.
 
 ## Layer configuration
@@ -86,13 +86,13 @@ that hosts dict.
 
 ## Actions
 
-### reinstall ###
+### reinstall (experimental) ###
 This layer provides a generic `reinstall` action that will invoke
 `Bigtop.reinstall_repo_packages`. This is meant to serve as a template for
 writing a Bigtop charm-specific action used to upgrade packages when a new
-Bigtop repository has been configured. See the
-[Spark reinstall action][spark-reinstall] as an example of extending this
-generic action.
+Bigtop repository has been configured. See the **Bigtop Versions** section for
+more details. For an example charm that extends this generic action, see the
+[Spark reinstall action][spark-reinstall].
 
 [spark-reinstall]: https://github.com/apache/bigtop/blob/master/bigtop-packages/src/charm/spark/layer-spark/actions/reinstall
 
@@ -121,6 +121,11 @@ juju deploy hadoop-namenode --resource bigtop-repo=/tmp/branch-1.1.zip
 
 ## Bigtop Versions
 
+> **Note**: Support for changing Bigtop versions at runtime should be
+considered experimental in the current release. Users are encouraged to try
+this feature in development environments. Changing the Bigtop version in a
+production deployment is not yet recommended.
+
 The `bigtop_version` config option can be used to change the version of
 Bigtop at runtime:
 
@@ -139,14 +144,13 @@ re-configure `bigtop_version`:
     juju config <charm> bigtop_version=1.2.0
 
 This layer does **not** perform any automatic upgrades. User intervention is
-always required by calling the `reinstall` action before bits are changed
-on disk.
+always required by calling the `reinstall` action to update system packages.
 
 ## Unit Tests
 
 To run unit tests for this layer, change to the root directory of the
 layer in a terminal, and run `tox -c tox_unit.ini`. To tweak settings,
-such as making the tests more or less verbose, edit tox_unit.ini.
+such as making the tests more or less verbose, edit `tox_unit.ini`.
 
 
 # Contributing

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,3 +1,5 @@
+reinstall:
+    description: Reinstall packages with the version available in the repo.
 smoke-test:
     description: |
       Verify a Bigtop service is working by executing a smoke test. The

--- a/actions/reinstall
+++ b/actions/reinstall
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+################################################################################
+# Bigtop reinstall template
+#
+# This provides the ability for Bigtop charms to reinstall their payload when
+# a new bigtop_version is configured. This should be modified as needed for
+# individual charms (see layer-spark for an example). Specifically, you should
+# determine what outcome is considered "succesful" and what warrants a
+# "failure", and set the action outcome/output as appropriate.
+################################################################################
+import sys
+sys.path.append('lib')
+
+from charmhelpers.core import hookenv
+from charms.layer.apache_bigtop_base import Bigtop
+from charms.reactive import is_state
+
+
+def fail(msg):
+    hookenv.action_set({'outcome': 'failure'})
+    hookenv.action_fail(msg)
+    sys.exit()
+
+
+if not is_state('bigtop.version.changed'):
+    fail('No repository changes found; nothing to reinstall.')
+
+bigtop = Bigtop()
+result = bigtop.reinstall_repo_packages()
+
+if result == 'success':
+    hookenv.status_set('active', 'reinstall was successful')
+    hookenv.action_set({'outcome': 'success'})
+else:
+    fail("Failed to reinstall. Check 'juju debug-log' for details.")

--- a/actions/reinstall
+++ b/actions/reinstall
@@ -48,4 +48,5 @@ if result == 'success':
     hookenv.status_set('active', 'reinstall was successful')
     hookenv.action_set({'outcome': 'success'})
 else:
-    fail("Failed to reinstall. Check 'juju debug-log' for details.")
+    fail('Reinstall failed; hiera data and package repos have been restored '
+         'to the previous working state.')

--- a/actions/reinstall
+++ b/actions/reinstall
@@ -27,7 +27,7 @@
 import sys
 sys.path.append('lib')
 
-from charmhelpers.core import hookenv
+from charmhelpers.core import hookenv, unitdata
 from charms.layer.apache_bigtop_base import Bigtop
 from charms.reactive import is_state
 
@@ -39,7 +39,14 @@ def fail(msg):
 
 
 if not is_state('bigtop.version.changed'):
-    fail('No repository changes found; nothing to reinstall.')
+    fail('No Bigtop version changes were found; nothing to reinstall.')
+
+# NB: CHANGE THE FOLLOWING UNITDATA KEY
+# Each charm ready for a reinstall should render a new site.yaml and set
+# kv data to signal that a new version is ready to be installed. Change
+# '<CHARM>.version.repo' to the key set by your charm.
+if not unitdata.kv().get('<CHARM>.version.repo', False):
+    fail('Charm is not prepared to run the reinstall action.')
 
 bigtop = Bigtop()
 result = bigtop.reinstall_repo_packages()

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,12 @@
 options:
+  bigtop_version:
+    type: string
+    default: '1.2.0'
+    description: |
+        Apache Bigtop release version. The default, '1.2.0' will use the
+        current GA release, Bigtop 1.2.0, for all hiera data, puppet recipes,
+        and installable packages. Set this to 'master' to use the latest
+        upstream bits.
   install-cuda:
     type: boolean
     default: false

--- a/layer.yaml
+++ b/layer.yaml
@@ -28,15 +28,6 @@ defines:
     default: 'hadoop'
     description: 'Space seperated list of bigtop component to be installed'
 
-  bigtop_version:
-    type: string
-    default: '1.2.0'
-    description: |
-        Apache Bigtop release version. The default, '1.2.0' will use the
-        current GA release, Bigtop 1.2.0, for all hiera data, puppet recipes,
-        and installable packages. Set this to 'master' to use the latest
-        upstream bits.
-
   bigtop_smoketest_components:
     type: array
     items: {type: string}

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -166,16 +166,10 @@ class Bigtop(object):
             )
         elif bigtop_version == '1.2.1' or bigtop_version == 'master':
             if dist_name == 'ubuntu' and dist_series == 'xenial':
-                if repo_arch == "x86_64":
-                    bigtop_repo_url = ('https://ci.bigtop.apache.org/'
-                                       'job/Bigtop-trunk-repos/'
-                                       'OS=ubuntu-16.04,label=docker-slave/'
-                                       'ws/output/apt')
-                else:
-                    bigtop_repo_url = ('https://ci.bigtop.apache.org/'
-                                       'job/Bigtop-trunk-repos/'
-                                       'OS=ubuntu-16.04-{},label=docker-slave/'
-                                       'ws/output/apt'.format(repo_arch))
+                bigtop_repo_url = ('https://ci.bigtop.apache.org/'
+                                   'job/Bigtop-trunk-repos/'
+                                   'OS=ubuntu-16.04,label=docker-slave/'
+                                   'ws/output/apt')
             else:
                 raise BigtopError(
                     u"Charms only support Bigtop 'master' on Ubuntu/Xenial.")

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -167,12 +167,12 @@ class Bigtop(object):
         elif bigtop_version == '1.2.1' or bigtop_version == 'master':
             if dist_name == 'ubuntu' and dist_series == 'xenial':
                 if repo_arch == "x86_64":
-                    bigtop_repo_url = ('http://ci.bigtop.apache.org:8080/'
+                    bigtop_repo_url = ('https://ci.bigtop.apache.org/'
                                        'job/Bigtop-trunk-repos/'
                                        'OS=ubuntu-16.04,label=docker-slave/'
                                        'ws/output/apt')
                 else:
-                    bigtop_repo_url = ('http://ci.bigtop.apache.org:8080/'
+                    bigtop_repo_url = ('https://ci.bigtop.apache.org/'
                                        'job/Bigtop-trunk-repos/'
                                        'OS=ubuntu-16.04-{},label=docker-slave/'
                                        'ws/output/apt'.format(repo_arch))
@@ -205,20 +205,24 @@ class Bigtop(object):
         self.apply_patches()
         self.render_hiera_yaml()
 
-    def refresh_bigtop_source(self):
+    def refresh_bigtop_release(self):
         """
         Refresh the bigtop source.
 
-        Reset the apt pin, fetch the bigtop repo for the configured bigtop
-        version, apply relevant patches, and setup the hiera.yaml. This method
+        Reset the apt pin, fetch the bigtop source for the configured bigtop
+        version, apply relevant patches, and setup the apt repo. This method
         is triggered any time bigtop_version changes to ensure we have the
         correct repo source in place before we render a site.yaml and trigger
         puppet.
         """
-        self.pin_bigtop_packages()
+        # NB: set a low priority so we can query new package versions, but
+        # won't accidentally install them until the user runs an upgrade action.
+        self.pin_bigtop_packages(priority=10)
         self.fetch_bigtop_release()
         self.apply_patches()
-        self.render_hiera_yaml()
+
+        # Add the apt repo so we can query for package changes.
+        self.update_bigtop_repo()
 
     def install_swap(self):
         """
@@ -266,7 +270,6 @@ class Bigtop(object):
     def install_java(self):
         """
         Possibly install java.
-
         """
         java_package = self.options.get("install_java")
         if not java_package:
@@ -286,18 +289,86 @@ class Bigtop(object):
             r'#? *JAVA_HOME *=.*': 'JAVA_HOME={}'.format(java_home_),
         }, append_non_matches=True)
 
-    def pin_bigtop_packages(self):
+    def pin_bigtop_packages(self, priority=900):
         """
-        Tell Ubuntu to use the Bigtop repo where possible, so that we
-        don't actually fetch newer packages from universe.
+        By default, give a higher priority to the Bigtop repo so that we don't
+        fetch newer packages from universe.
+
+        During an upgrade, we want to set the priority < 100. This
+        will allow us to query for a new version and inform the user that an
+        upgrade is available without actually upgrading any packages.
         """
         origin = urlparse(self.bigtop_apt).hostname
 
         with open("resources/pin-bigtop.txt", "r") as pin_file:
-            pin_file = pin_file.read().format(origin=origin)
+            pin_file = pin_file.read().format(origin=origin, priority=priority)
 
-        with open("/etc/apt/preferences.d/bigtop-999", "w") as out_file:
+        # NB: prefix the filename with '000' to come before any Bigtop pin.
+        # The first preference file read controls the overall apt prefs.
+        with open("/etc/apt/preferences.d/000-bigtop-juju", "w") as out_file:
             out_file.write(pin_file)
+
+    def update_bigtop_repo(self, remove=False):
+        """
+        Add or Remove a bigtop repository.
+
+        Typically, the Bigtop repository is configured when running 'puppet
+        apply'. However, sometimes the system needs to know about a repo
+        outside of puppet. For example, when changing the bigtop version, we
+        use this method to add a new repo and query for package updates
+        without actually installing anything.
+
+        :param: bool remove: True to remove the repo; False to add it
+        """
+        distro = lsb_release()['DISTRIB_ID'].lower()
+        if distro == 'ubuntu':
+            # NB: inner quotes are required so add-apt-repo sees the whole
+            # string as the repo.
+            repo = "deb {} bigtop contrib".format(self.bigtop_apt)
+            flags = '-yur' if remove else '-yu'
+            cmd = ['add-apt-repository', flags, repo]
+            try:
+                subprocess.check_call(cmd)
+            except subprocess.CalledProcessError:
+                hookenv.log('Failed to update the bigtop repo with: {}'.format(
+                            ' '.join(cmd)), hookenv.ERROR)
+            else:
+                hookenv.log('Successfully updated the bigtop repo',
+                            hookenv.INFO)
+
+    def check_bigtop_repo_package(self, pkg):
+        """
+        Return the package version from the repo if different than the version
+        that is currently installed .
+
+        :param: str pkg: package name as known by the package manager
+        :returns: str ver_str: version of new repo package, or None
+        """
+        distro = lsb_release()['DISTRIB_ID'].lower()
+        if distro == 'ubuntu':
+            # NB: we cannot use the charmhelpers.fetch.apt_cache nor the
+            # apt module from the python3-apt deb as they are only available
+            # as system packages. Charms with use_system_packages=False in
+            # layer.yaml would fail. Subprocess apt-cache madison instead.
+            madison_cmd = ['apt-cache', 'madison', pkg]
+            grep_cmd = ['grep', self.bigtop_apt]
+            p1 = subprocess.Popen(madison_cmd, stdout=subprocess.PIPE)
+            p2 = subprocess.Popen(grep_cmd, stdin=p1.stdout,
+                                  stdout=subprocess.PIPE)
+            p1.stdout.close()
+            madison_output = p2.communicate()[0].strip().decode()
+            p1.wait()
+
+            # madison_output will look like this:
+            #  spark-core |    2.1.1-1 | <repo>
+            try:
+                ver_str = madison_output.split('|')[1].strip()
+            except IndexError:
+                hookenv.log(
+                    'Could not find {} in the configured repo'.format(pkg),
+                    hookenv.WARNING)
+                return None
+        return ver_str if ver_str != get_package_version(pkg) else None
 
     def check_localdomain(self):
         """
@@ -512,16 +583,8 @@ class Bigtop(object):
             roles = [roles]
         overrides = overrides or {}
         if not self.site_yaml.exists():
-            # If our site.yaml doesn't exist, we may be in the middle of a
-            # version change. If so, the application config-changed may be
-            # calling this method before we've put the new bigtop repo bits on
-            # disk. Check for that and refresh if needed. Otherwise, we're no
-            # good without a base site.yaml, so raise an error.
-            if is_state('config.changed.bigtop_version'):
-                self.refresh_bigtop_source()
-            else:
-                raise BigtopError(
-                    u"Bigtop site.yaml not found: {}".format(self.site_yaml))
+            raise BigtopError(
+                u"Bigtop site.yaml not found: {}".format(self.site_yaml))
         site_data = yaml.load(self.site_yaml.text())
 
         # define common defaults
@@ -724,6 +787,53 @@ class Bigtop(object):
                 smoke_out = e.output
         return smoke_out
 
+    def reinstall_repo_packages(self, remove_pkgs=None):
+        """
+        Trigger a puppet apply to reinstall packages from a bigtop repository.
+
+        Call this after a new bigtop version has been configured by the user.
+        Typically called from a charm action, this method will:
+        - optionally remove packages before reconfiguring the system
+        - ensure the repo for the current bigtop version has priority
+        - render a site-wide hiera.yaml pointing to the current bigtop source
+        - trigger puppet apply
+
+        :param: str remove_pkgs: 'apt-get remove' this prior to any reinstall
+        """
+        # To support both upgrades and downgrades with this method, we may need
+        # a package list that we can use to remove all charm-related packages
+        # and ensure reinstalled versions are accurate. This can be any string
+        # that would be valid for 'apt-get remove'.
+        if remove_pkgs:
+            cmd = ['apt-get', 'remove', '-qqy', remove_pkgs]
+            try:
+                subprocess.check_call(cmd)
+            except subprocess.CalledProcessError:
+                # NB: at this point, we have not altered our apt repo or
+                # system-wide puppet config. Simply trigger puppet to put the
+                # system back to the way it was.
+                hookenv.log(
+                    'Package removal failed; triggering puppet apply to return '
+                    'the system to the previous working state.', hookenv.ERROR)
+                self.trigger_puppet()
+                return
+
+        # Pin the repo, point to the right bigtop source, and trigger puppet.
+        # NB: When configuring a new bigtop version, the repo priority is set
+        # low. Set it higher so new repo packages will take precedent over the
+        # currently installed versions.
+        self.pin_bigtop_packages(priority=900)
+        self.render_hiera_yaml()
+        self.trigger_puppet()
+
+        # We added a new repo when the bigtop version changed. Remove it now
+        # that our reinstallation is complete.
+        self.update_bigtop_repo(remove=True)
+
+        # We've processed the version change; remove our changed state
+        remove_state('bigtop.version.changed')
+        return "success"
+
 
 def get_hadoop_version():
     jhome = java_home()
@@ -747,7 +857,7 @@ def get_hadoop_version():
 
 def get_package_version(pkg):
     """
-    Return a version string for a given package name.
+    Return a version string for an installed package name.
 
     :param: str pkg: package name as known by the package manager
     :returns: str ver_str: version string from package manager, or empty string
@@ -765,7 +875,7 @@ def get_package_version(pkg):
                 ver_str = subprocess.check_output(cmd).strip().decode()
             except subprocess.CalledProcessError as e:
                 hookenv.log(
-                    'Error getting package version: {}'.format(e.output),
+                    'Error getting local package version: {}'.format(e.output),
                     hookenv.ERROR)
         return ver_str
     else:

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -422,7 +422,7 @@ class Bigtop(object):
 
         # Make sure the repo looks like we expect
         if Path(self.bigtop_base / 'bigtop.bom').exists():
-            hookenv.status_set('maintenance', 'bigtop source fetched')
+            hookenv.status_set('waiting', 'bigtop source fetched')
         else:
             hookenv.status_set('blocked', 'invalid bigtop source')
             raise BigtopError(

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -298,15 +298,16 @@ class Bigtop(object):
         will allow us to query for a new version and inform the user that an
         upgrade is available without actually upgrading any packages.
         """
+        # Substitute template vars
         origin = urlparse(self.bigtop_apt).hostname
-
         with open("resources/pin-bigtop.txt", "r") as pin_file:
-            pin_file = pin_file.read().format(origin=origin, priority=priority)
+            pref_txt = pin_file.read().format(origin=origin, priority=priority)
 
+        # Write the modified contents to an apt pref file
         # NB: prefix the filename with '000' to come before any Bigtop pin.
         # The first preference file read controls the overall apt prefs.
-        with open("/etc/apt/preferences.d/000-bigtop-juju", "w") as out_file:
-            out_file.write(pin_file)
+        pref_dst = Path('/etc/apt/preferences.d/000-bigtop-juju')
+        pref_dst.write_text(pref_txt)
 
     def update_bigtop_repo(self, remove=False):
         """
@@ -368,7 +369,9 @@ class Bigtop(object):
                     'Could not find {} in the configured repo'.format(pkg),
                     hookenv.WARNING)
                 return None
-        return ver_str if ver_str != get_package_version(pkg) else None
+            return ver_str if ver_str != get_package_version(pkg) else None
+        else:
+            raise BigtopError(u"Repo query is only supported on Ubuntu")
 
     def check_localdomain(self):
         """

--- a/reactive/apache_bigtop_base.py
+++ b/reactive/apache_bigtop_base.py
@@ -1,4 +1,4 @@
-from charms.reactive import when_any, when_not, when_none
+from charms.reactive import when_any, when_not, when_none, when
 from charms.reactive import RelationBase, set_state, is_state
 from charms.reactive.helpers import data_changed, any_states
 from charmhelpers.core import hookenv, unitdata
@@ -33,6 +33,17 @@ def fetch_bigtop():
         hookenv.status_set('waiting',
                            'unable to fetch apache bigtop: checksum error'
                            ' (will retry)')
+
+
+@when('bigtop.available', 'config.changed.bigtop-version')
+def change_bigtop_version():
+    # Make sure the config has actually changed; on initial initial,
+    # config.changed.foo is always set. We don't want to run through
+    # fetch_bigtop twice in that case.
+    cur_ver = hookenv.config()['bigtop-version']
+    pre_ver = hookenv.config()['bigtop-version'].previous()
+    if cur_ver != pre_ver:
+        fetch_bigtop()
 
 
 @when_any('java.ready', 'hadoop-plugin.java.ready')

--- a/reactive/apache_bigtop_base.py
+++ b/reactive/apache_bigtop_base.py
@@ -36,17 +36,17 @@ def fetch_bigtop():
         set_state('bigtop.available')
 
 
-@when('bigtop.available', 'config.changed.bigtop-version')
+@when('bigtop.available', 'config.changed.bigtop_version')
 def change_bigtop_version():
     # Make sure the config has actually changed; on initial initial,
     # config.changed.foo is always set. We don't want to run through
     # fetch_bigtop twice in that case.
-    cur_ver = hookenv.config()['bigtop-version']
-    pre_ver = hookenv.config()['bigtop-version'].previous()
+    cur_ver = hookenv.config()['bigtop_version']
+    pre_ver = hookenv.config().previous('bigtop_version')
     if cur_ver != pre_ver:
         hookenv.log('New bigtop version requested: {}. Refreshing source.'
                     .format(cur_ver))
-        Bigtop.refresh_bigtop_source()
+        Bigtop().refresh_bigtop_source()
 
 
 @when_any('java.ready', 'hadoop-plugin.java.ready')

--- a/resources/pin-bigtop.txt
+++ b/resources/pin-bigtop.txt
@@ -1,3 +1,3 @@
 Package: *
 Pin: origin "{origin}"
-Pin-Priority: 999
+Pin-Priority: {priority}

--- a/tests/unit/test_bigtop.py
+++ b/tests/unit/test_bigtop.py
@@ -145,7 +145,7 @@ class TestBigtopUnit(Harness):
         mock_utils.cpu_arch.return_value = 'foo'
         self.assertEqual(self.bigtop.get_repo_url('master'),
                          ('https://ci.bigtop.apache.org/job/Bigtop-trunk-repos/'
-                          'OS=ubuntu-16.04-foo,label=docker-slave/ws/output/apt'))
+                          'OS=ubuntu-16.04,label=docker-slave/ws/output/apt'))
 
         # test bad version on xenial should throw an exception
         self.assertRaises(

--- a/tests/unit/test_bigtop.py
+++ b/tests/unit/test_bigtop.py
@@ -28,7 +28,7 @@ class TestBigtopUnit(Harness):
     @mock.patch('charms.layer.apache_bigtop_base.Bigtop.bigtop_version',
                 new_callable=mock.PropertyMock)
     def setUp(self, mock_ver, mock_hookenv):
-        mock_ver.return_value = 'master'
+        mock_ver.return_value = '1.2.0'
         super(TestBigtopUnit, self).setUp()
         self.bigtop = Bigtop()
 
@@ -510,7 +510,7 @@ class TestBigtopUnit(Harness):
 
         '''
         set_state('apache-bigtop-base.puppet_queued')
-        mock_ver.return_value = 'master'
+        mock_ver.return_value = '1.2.0'
         Bigtop._handle_queued_puppet()
         self.assertTrue(mock_trigger.called)
         self.assertFalse(is_state('apache-bigtop-base.puppet_queued'))

--- a/tests/unit/test_bigtop.py
+++ b/tests/unit/test_bigtop.py
@@ -24,9 +24,10 @@ class TestBigtopUnit(Harness):
 
     '''
 
+    @mock.patch('charms.layer.apache_bigtop_base.hookenv')
     @mock.patch('charms.layer.apache_bigtop_base.Bigtop.bigtop_version',
                 new_callable=mock.PropertyMock)
-    def setUp(self, mock_ver):
+    def setUp(self, mock_ver, mock_hookenv):
         mock_ver.return_value = 'master'
         super(TestBigtopUnit, self).setUp()
         self.bigtop = Bigtop()
@@ -41,53 +42,130 @@ class TestBigtopUnit(Harness):
         self.assertEqual(type(self.bigtop.bigtop_base), Path)
         self.assertEqual(type(self.bigtop.site_yaml), Path)
 
-    @unittest.skip('noop')
-    def test_install(self):
+    @mock.patch('charms.layer.apache_bigtop_base.Bigtop.render_hiera_yaml')
+    @mock.patch('charms.layer.apache_bigtop_base.Bigtop.apply_patches')
+    @mock.patch('charms.layer.apache_bigtop_base.Bigtop.install_puppet_modules')
+    @mock.patch('charms.layer.apache_bigtop_base.Bigtop.fetch_bigtop_release')
+    @mock.patch('charms.layer.apache_bigtop_base.Bigtop.check_reverse_dns')
+    @mock.patch('charms.layer.apache_bigtop_base.Bigtop.check_localdomain')
+    @mock.patch('charms.layer.apache_bigtop_base.Bigtop.pin_bigtop_packages')
+    @mock.patch('charms.layer.apache_bigtop_base.Bigtop.install_java')
+    @mock.patch('charms.layer.apache_bigtop_base.Bigtop.install_swap')
+    @mock.patch('charms.layer.apache_bigtop_base.is_container')
+    def test_install(self, mock_container, mock_swap, mock_java, mock_pin,
+                     mock_local, mock_dns, mock_fetch, mock_puppet, mock_apply,
+                     mock_hiera):
         '''
-        Nothing to test that is not covered by the linter, or covered by
-        integration tests.
+        Verify install calls expected class methods.
 
         '''
+        mock_container.return_value = False
+        self.bigtop.install()
+        self.assertTrue(mock_swap.called)
+        self.assertTrue(mock_java.called)
+        self.assertTrue(mock_pin.called)
+        self.assertTrue(mock_local.called)
+        self.assertTrue(mock_dns.called)
+        self.assertTrue(mock_fetch.called)
+        self.assertTrue(mock_puppet.called)
+        self.assertTrue(mock_apply.called)
+        self.assertTrue(mock_hiera.called)
+
+    @mock.patch('charms.layer.apache_bigtop_base.Bigtop.update_bigtop_repo')
+    @mock.patch('charms.layer.apache_bigtop_base.Bigtop.apply_patches')
+    @mock.patch('charms.layer.apache_bigtop_base.Bigtop.fetch_bigtop_release')
+    @mock.patch('charms.layer.apache_bigtop_base.Bigtop.pin_bigtop_packages')
+    def test_refresh_bigtop_release(self, mock_pin, mock_fetch, mock_apply,
+                                    mock_update):
+        '''
+        Verify refresh calls expected class methods.
+
+        '''
+        self.bigtop.refresh_bigtop_release()
+        self.assertTrue(mock_pin.called)
+        self.assertTrue(mock_fetch.called)
+        self.assertTrue(mock_apply.called)
+        self.assertTrue(mock_update.called)
 
     @mock.patch('charms.layer.apache_bigtop_base.utils')
     @mock.patch('charms.layer.apache_bigtop_base.layer.options')
     @mock.patch('charms.layer.apache_bigtop_base.lsb_release')
-    def test_get_repo_url(self, mock_lsb_release,
+    @mock.patch('charms.layer.apache_bigtop_base.Bigtop.bigtop_version',
+                new_callable=mock.PropertyMock)
+    def test_get_repo_url(self, mock_ver, mock_lsb_release,
                           mock_options, mock_utils):
         '''
-        Test to verify that we setup an appropriate repository.
+        Verify that we setup an appropriate repository.
 
         '''
-        # master on trusty should throw an exception
-        mock_lsb_release.return_value = {'DISTRIB_CODENAME': 'trusty',
-                                         'DISTRIB_ID': 'ubuntu',
-                                         'DISTRIB_RELEASE': '14.04'}
-        self.assertRaises(
-            BigtopError,
-            self.bigtop.get_repo_url,
-            'master')
+        mock_ver.return_value = '1.1.0'
 
-        # master on non-ubuntu should throw an exception
-        mock_lsb_release.return_value = {'DISTRIB_CODENAME': 'xenial',
+        # non-ubuntu should throw an exception
+        mock_lsb_release.return_value = {'DISTRIB_CODENAME': 'foo',
                                          'DISTRIB_ID': 'centos',
                                          'DISTRIB_RELEASE': '7'}
         self.assertRaises(
             BigtopError,
             self.bigtop.get_repo_url,
+            '1.1.0')
+
+        # 1.1.0 on trusty/non-power
+        mock_utils.cpu_arch.return_value = 'foo'
+        mock_lsb_release.return_value = {'DISTRIB_CODENAME': 'trusty',
+                                         'DISTRIB_ID': 'ubuntu',
+                                         'DISTRIB_RELEASE': '14.04'}
+        self.assertEqual(self.bigtop.get_repo_url('1.1.0'),
+                         ('http://bigtop-repos.s3.amazonaws.com/releases/'
+                          '1.1.0/ubuntu/trusty/foo'))
+
+        # 1.1.0 on trusty/power
+        mock_utils.cpu_arch.return_value = 'ppc64le'
+        self.assertEqual(self.bigtop.get_repo_url('1.1.0'),
+                         ('http://bigtop-repos.s3.amazonaws.com/releases/'
+                          '1.1.0/ubuntu/vivid/ppc64el'))
+
+        # master should fail on trusty
+        self.assertRaises(
+            BigtopError,
+            self.bigtop.get_repo_url,
             'master')
 
-        # bad version on xenial should throw an exception
+        # 1.2.0 on xenial
+        mock_ver.return_value = '1.2.0'
+        mock_utils.cpu_arch.return_value = 'foo'
         mock_lsb_release.return_value = {'DISTRIB_CODENAME': 'xenial',
                                          'DISTRIB_ID': 'ubuntu',
                                          'DISTRIB_RELEASE': '16.04'}
+        self.assertEqual(self.bigtop.get_repo_url('1.2.0'),
+                         ('http://bigtop-repos.s3.amazonaws.com/releases/'
+                          '1.2.0/ubuntu/16.04/foo'))
+
+        # master on xenial
+        mock_ver.return_value = 'master'
+        mock_utils.cpu_arch.return_value = 'foo'
+        self.assertEqual(self.bigtop.get_repo_url('master'),
+                         ('https://ci.bigtop.apache.org/job/Bigtop-trunk-repos/'
+                          'OS=ubuntu-16.04-foo,label=docker-slave/ws/output/apt'))
+
+        # test bad version on xenial should throw an exception
         self.assertRaises(
             BigtopError,
             self.bigtop.get_repo_url,
             '0.0.0')
 
-    @unittest.skip('noop')
-    def test_install_swap(self):
-        '''Mainly system calls -- covered by linter and basic deploy tests.'''
+    @mock.patch('charms.layer.apache_bigtop_base.subprocess')
+    def test_install_swap_when_swap_exists(self, mock_sub):
+        '''
+        Verify we do attempt to install swap space if it already exists.
+
+        '''
+        mock_sub.check_output.return_value = b"foo\nbar"
+        mock_sub.reset_mock()
+        self.bigtop.install_swap()
+
+        # We reset the mock, so here we're verifying no other subprocess
+        # calls were made.
+        mock_sub.check_call.assert_not_called()
 
     @mock.patch('charms.layer.apache_bigtop_base.lsb_release')
     @mock.patch('charms.layer.apache_bigtop_base.utils')
@@ -125,6 +203,125 @@ class TestBigtopUnit(Harness):
         self.bigtop.install_java()
         self.assertTrue(mock_fetch.add_source.called)
         self.assertTrue(mock_fetch.apt_update.called)
+
+    @mock.patch('charms.layer.apache_bigtop_base.Path')
+    def test_pin_bigtop_packages(self, mock_path):
+        '''
+        Verify the apt template is opened and written to a (mocked) file.
+
+        '''
+        mock_dst = mock.Mock()
+        mock_path.return_value = mock_dst
+
+        self.bigtop.pin_bigtop_packages(priority=100)
+        self.assertTrue(mock_dst.write_text.called)
+
+    @mock.patch('charms.layer.apache_bigtop_base.subprocess')
+    @mock.patch('charms.layer.apache_bigtop_base.lsb_release')
+    @mock.patch('charms.layer.apache_bigtop_base.Bigtop.bigtop_apt',
+                new_callable=mock.PropertyMock)
+    def test_update_bigtop_repo(self, mock_apt, mock_lsb_release, mock_sub):
+        '''
+        Verify a bigtop apt repository is added/removed.
+
+        '''
+        # non-ubuntu should not invoke a subprocess call
+        mock_lsb_release.return_value = {'DISTRIB_CODENAME': 'foo',
+                                         'DISTRIB_ID': 'centos',
+                                         'DISTRIB_RELEASE': '7'}
+        self.bigtop.update_bigtop_repo()
+        mock_sub.check_call.assert_not_called()
+
+        # verify args when adding a repo on ubuntu
+        mock_apt.return_value = 'foo'
+        mock_lsb_release.return_value = {'DISTRIB_CODENAME': 'xenial',
+                                         'DISTRIB_ID': 'ubuntu',
+                                         'DISTRIB_RELEASE': '16.04'}
+        self.bigtop.update_bigtop_repo()
+        mock_sub.check_call.assert_called_with(
+            ['add-apt-repository', '-yu', 'deb foo bigtop contrib'])
+
+        # verify args when removing a repo on ubuntu
+        self.bigtop.update_bigtop_repo(remove=True)
+        mock_sub.check_call.assert_called_with(
+            ['add-apt-repository', '-yur', 'deb foo bigtop contrib'])
+
+        # verify we handle check_call errors
+        class MockException(Exception):
+            pass
+        mock_sub.CalledProcessError = MockException
+
+        def mock_raise(*args, **kwargs):
+            raise MockException('foo!')
+
+        mock_sub.check_call.side_effect = mock_raise
+        self.bigtop.update_bigtop_repo()
+
+    @mock.patch('charms.layer.apache_bigtop_base.get_package_version')
+    @mock.patch('charms.layer.apache_bigtop_base.hookenv')
+    @mock.patch('charms.layer.apache_bigtop_base.subprocess.Popen')
+    @mock.patch('charms.layer.apache_bigtop_base.lsb_release')
+    def test_check_bigtop_repo_package(self, mock_lsb_release, mock_sub,
+                                       mock_hookenv, mock_pkg_ver):
+        '''
+        Verify bigtop repo package queries.
+
+        '''
+        # non-ubuntu should raise an error
+        mock_lsb_release.return_value = {'DISTRIB_CODENAME': 'foo',
+                                         'DISTRIB_ID': 'centos',
+                                         'DISTRIB_RELEASE': '7'}
+        self.assertRaises(BigtopError,
+                          self.bigtop.check_bigtop_repo_package,
+                          'foo')
+
+        # reset with ubuntu
+        mock_lsb_release.return_value = {'DISTRIB_CODENAME': 'xenial',
+                                         'DISTRIB_ID': 'ubuntu',
+                                         'DISTRIB_RELEASE': '16.04'}
+
+        madison_proc = mock.Mock()
+        grep_proc = mock.Mock()
+
+        # simulate a missing repo pkg
+        grep_attrs = {'communicate.return_value': (b'', 'stderr')}
+        grep_proc.configure_mock(**grep_attrs)
+
+        # test a missing repo pkg (message should be logged)
+        mock_sub.return_value = madison_proc
+        mock_sub.return_value = grep_proc
+        mock_pkg_ver.return_value = ''
+        self.assertEqual(None, self.bigtop.check_bigtop_repo_package('foo'))
+        mock_hookenv.log.assert_called_once()
+        mock_hookenv.reset_mock()
+
+        # reset our grep args to simulate the repo pkg being found
+        grep_attrs = {'communicate.return_value': (b'pkg|1|repo', 'stderr')}
+        grep_proc.configure_mock(**grep_attrs)
+
+        # test a missing installed pkg (no log message)
+        mock_sub.return_value = madison_proc
+        mock_sub.return_value = grep_proc
+        mock_pkg_ver.return_value = ''
+        self.assertEqual('1', self.bigtop.check_bigtop_repo_package('foo'))
+        mock_hookenv.log.assert_not_called()
+        mock_hookenv.reset_mock()
+
+        # test repo and installed pkg versions are the same (no log message)
+        mock_sub.return_value = madison_proc
+        mock_sub.return_value = grep_proc
+        mock_pkg_ver.return_value = '1'
+        self.assertEqual(None, self.bigtop.check_bigtop_repo_package('foo'))
+        mock_hookenv.log.assert_not_called()
+        mock_hookenv.reset_mock()
+
+        # test repo pkg is newer than installed pkg (no log message)
+        mock_sub.return_value = madison_proc
+        mock_sub.return_value = grep_proc
+        mock_pkg_ver.return_value = '0'
+        self.assertEqual('1', self.bigtop.check_bigtop_repo_package('foo'))
+        mock_hookenv.log.assert_not_called()
+        mock_hookenv.reset_mock()
 
     @mock.patch('charms.layer.apache_bigtop_base.socket')
     @mock.patch('charms.layer.apache_bigtop_base.subprocess')
@@ -303,9 +500,10 @@ class TestBigtopUnit(Harness):
         self.assertTrue(is_state('apache-bigtop-base.puppet_queued'))
 
     @mock.patch('charms.layer.apache_bigtop_base.Bigtop.trigger_puppet')
+    @mock.patch('charms.layer.apache_bigtop_base.hookenv')
     @mock.patch('charms.layer.apache_bigtop_base.Bigtop.bigtop_version',
                 new_callable=mock.PropertyMock)
-    def test_handle_queued_puppet(self, mock_ver, mock_trigger):
+    def test_handle_queued_puppet(self, mock_ver, mock_hookenv, mock_trigger):
         '''
         Verify that we attempt to call puppet when it has been queued, and
         then clear the queued state.

--- a/tox_unit.ini
+++ b/tox_unit.ini
@@ -13,7 +13,7 @@ commands =
     nosetests -v --nocapture --with-coverage --cover-erase \
         --cover-package=apache_bigtop_base \
         --cover-package=charms.layer.apache_bigtop_base \
-        --cover-min-percentage=75 \
+        --cover-min-percentage=80 \
         tests/unit/
 deps =
     -r{toxinidir}/unit_test_requirements.txt


### PR DESCRIPTION
Allow users to specify the bigtop version as a runtime config option, e.g.:

    juju config spark bigtop_version='1.2.1'

On change, this layer will fetch new bigtop source and add a corresponding apt repository with a low priority. This allows individual charms to query for new package versions and inform the user of possible actions.

A `reinstall` action template is also included here.  This should be modified as needed for individual charms in case there are application-specific tasks to perform when changing package versions.

The upgrade workflow goes like this:
- configure a new bigtop_version
- this base layer will setup the new bigtop source/repo and set `bigtop.version.changed`
- charms should react to this new state by calling `Bigtop.check_bigtop_repo_package` with an appropriate package name
- if a new version is available, charms should set status to inform the user to run the `reinstall` action
- `reinstall` calls `Bigtop.reinstall_repo_packages` which points the site-wide hiera.yaml to the new bigtop source and subsequently calls `trigger_puppet`
- on success, `Bigtop.reinstall_repo_packages` will remove the `bigtop.version.changed` state
- charms should clean up any intermediate states they may have set during the `reinstall` action

I've also included unit tests for the new methods created by this PR.