### PR TITLE
unit test and copyright updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
-dist: trusty
-sudo: required
 language: python
+sudo: true
+dist: trusty
 python:
  - '3.5'
 
 install:
- - pip install tox
-
+  - make sysdeps
+env:
+  global:
+    - PATH=/snap/bin:$PATH
 script:
- - make lint unit_test
+ - make all

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
  - pip install tox
 
 script:
- - make all
+ - make lint unit_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 sudo: true
 dist: trusty
 python:
- - '3.5'
+  - '3.5'
 
 install:
   - make sysdeps
@@ -10,4 +10,4 @@ env:
   global:
     - PATH=/snap/bin:$PATH
 script:
- - make all
+  - make all

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,7 @@ clean:
 
 .PHONY: apt_prereqs
 apt_prereqs:
-	@which charm >/dev/null || sudo snap install charm
-	@# Need tox, but don't install the apt version unless we have to (don't want to conflict with pip)
+	@which charm >/dev/null || (sudo apt-get install -y snapd && sudo snap install charm)
 	@which tox >/dev/null || (sudo apt-get install -y python-pip && sudo pip install tox)
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ clean:
 
 .PHONY: apt_prereqs
 apt_prereqs:
+	@which charm >/dev/null || sudo snap install charm
 	@# Need tox, but don't install the apt version unless we have to (don't want to conflict with pip)
 	@which tox >/dev/null || (sudo apt-get install -y python-pip && sudo pip install tox)
 

--- a/Makefile
+++ b/Makefile
@@ -10,18 +10,20 @@ clean:
 	@rm -rf .tox
 	@find . -name "__pycache__" -type d -prune -exec rm -rf '{}' \;
 
-.PHONY: apt_prereqs
-apt_prereqs:
+.PHONY: sysdeps
+sysdeps:
 	@which charm >/dev/null || (sudo apt-get install -y snapd && sudo snap install charm --classic)
 	@which tox >/dev/null || (sudo apt-get install -y python-pip && sudo pip install tox)
 
 .PHONY: lint
-lint: apt_prereqs
+lint: sysdeps
+	@echo Starting linter...
 	@tox -c tox_unit.ini --notest
 	@PATH=.tox/py34/bin:.tox/py35/bin flake8 $(wildcard hooks reactive lib unit_tests tests)
+	@echo Starting proof...
 	@charm proof
 
 .PHONY: unit_test
-unit_test: apt_prereqs
+unit_test: sysdeps
 	@echo Starting unit tests...
-	tox -c tox_unit.ini
+	@tox -c tox_unit.ini

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean:
 
 .PHONY: apt_prereqs
 apt_prereqs:
-	@which charm >/dev/null || (sudo apt-get install -y snapd && sudo snap install charm)
+	@which charm >/dev/null || (sudo apt-get install -y snapd && sudo snap install charm --classic)
 	@which tox >/dev/null || (sudo apt-get install -y python-pip && sudo pip install tox)
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean:
 
 .PHONY: sysdeps
 sysdeps:
-	@which charm >/dev/null || (sudo apt-get install -y snapd && sudo snap install charm --classic)
+	@which charm >/dev/null || (sudo apt-get install -y snapd && sudo snap install charm --candidate)
 	@which tox >/dev/null || (sudo apt-get install -y python-pip && sudo pip install tox)
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,10 @@ all: lint unit_test
 
 .PHONY: clean
 clean:
+	@rm -rf .cache
 	@rm -f .coverage
 	@rm -rf .tox
+	@find . -name "__pycache__" -type d -prune -exec rm -rf '{}' \;
 
 .PHONY: apt_prereqs
 apt_prereqs:
@@ -17,8 +19,9 @@ apt_prereqs:
 lint: apt_prereqs
 	@tox -c tox_unit.ini --notest
 	@PATH=.tox/py34/bin:.tox/py35/bin flake8 $(wildcard hooks reactive lib unit_tests tests)
+	@charm proof
 
 .PHONY: unit_test
 unit_test: apt_prereqs
-	@echo Starting tests...
+	@echo Starting unit tests...
 	tox -c tox_unit.ini

--- a/copyright
+++ b/copyright
@@ -1,0 +1,16 @@
+Format: http://dep.debian.net/deps/dep5/
+
+Files: *
+Copyright: Copyright 2015, Canonical Ltd., All Rights Reserved, The Apache Software Foundation
+License: Apache License 2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+     http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+amulet
+flake8
+pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+skipsdist=True
+envlist = py34, py35
+skip_missing_interpreters = True
+
+[testenv]
+commands = pytest -v
+deps =
+    -r{toxinidir}/requirements.txt
+
+[flake8]
+exclude=docs
+
+[pytest]
+norecursedirs = unit
+python_files = *.py
+testpaths = tests

--- a/tox_unit.ini
+++ b/tox_unit.ini
@@ -17,7 +17,6 @@ commands =
         tests/unit/
 deps =
     -r{toxinidir}/unit_test_requirements.txt
-    -r{toxinidir}/wheelhouse.txt
     coverage
 setenv =
     PYTHONPATH={toxinidir}/reactive:{toxinidir}/lib/

--- a/unit_test_requirements.txt
+++ b/unit_test_requirements.txt
@@ -1,4 +1,7 @@
+charms.reactive
 flake8
-nose
+jujubigdata>=7.0.0,<8.0.0
 mock
-charms.reactive    
+netifaces==0.10.4
+nose
+path.py


### PR DESCRIPTION
- add apache2 copyright like all our bigtop layers
- update makefile to include proof as part of the lint target

We also need to remove charm reqs (wheelhouse.txt) from tox_unit.ini.  Building a charm processes wheelhouse.txt and put those reqs in a ./wheelhouse subdir.  Tox will fail to run on a built charm because wheelhouse.txt will not exit.  Put whatever we need for unit tests into unit_test_requirements.txt since that file will be in the built charm output.