### PR TITLE
arch-specific repo required for trunk

### DIFF
--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -323,8 +323,6 @@ class Bigtop(object):
         """
         distro = lsb_release()['DISTRIB_ID'].lower()
         if distro == 'ubuntu':
-            # NB: inner quotes are required so add-apt-repo sees the whole
-            # string as the repo.
             repo = "deb {} bigtop contrib".format(self.bigtop_apt)
             flags = '-yur' if remove else '-yu'
             cmd = ['add-apt-repository', flags, repo]

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -166,10 +166,16 @@ class Bigtop(object):
             )
         elif bigtop_version == '1.2.1' or bigtop_version == 'master':
             if dist_name == 'ubuntu' and dist_series == 'xenial':
-                bigtop_repo_url = ('https://ci.bigtop.apache.org/'
-                                   'job/Bigtop-trunk-repos/'
-                                   'OS=ubuntu-16.04,label=docker-slave/'
-                                   'ws/output/apt')
+                if repo_arch == "x86_64":
+                    bigtop_repo_url = ('https://ci.bigtop.apache.org/'
+                                       'job/Bigtop-trunk-repos/'
+                                       'OS=ubuntu-16.04,label=docker-slave/'
+                                       'ws/output/apt')
+                else:
+                    bigtop_repo_url = ('https://ci.bigtop.apache.org/'
+                                       'job/Bigtop-trunk-repos/'
+                                       'OS=ubuntu-16.04-{},label=docker-slave/'
+                                       'ws/output/apt'.format(repo_arch))
             else:
                 raise BigtopError(
                     u"Charms only support Bigtop 'master' on Ubuntu/Xenial.")

--- a/tests/unit/test_bigtop.py
+++ b/tests/unit/test_bigtop.py
@@ -140,12 +140,19 @@ class TestBigtopUnit(Harness):
                          ('http://bigtop-repos.s3.amazonaws.com/releases/'
                           '1.2.0/ubuntu/16.04/foo'))
 
-        # master on xenial
+        # master on xenial/intel
+        mock_ver.return_value = 'master'
+        mock_utils.cpu_arch.return_value = 'x86_64'
+        self.assertEqual(self.bigtop.get_repo_url('master'),
+                         ('https://ci.bigtop.apache.org/job/Bigtop-trunk-repos/'
+                          'OS=ubuntu-16.04,label=docker-slave/ws/output/apt'))
+
+        # master on xenial/non-intel
         mock_ver.return_value = 'master'
         mock_utils.cpu_arch.return_value = 'foo'
         self.assertEqual(self.bigtop.get_repo_url('master'),
                          ('https://ci.bigtop.apache.org/job/Bigtop-trunk-repos/'
-                          'OS=ubuntu-16.04,label=docker-slave/ws/output/apt'))
+                          'OS=ubuntu-16.04-foo,label=docker-slave/ws/output/apt'))
 
         # test bad version on xenial should throw an exception
         self.assertRaises(


### PR DESCRIPTION
Binary packages for bigtop trunk are only available in the arch-specific
builder repositories. The multiple arches seen here only include no-arch
pkgs for non-intel arches:

https://ci.bigtop.apache.org/job/Bigtop-trunk-repos/OS=ubuntu-16.04,label=docker-slave/ws/output/apt/dists/bigtop/contrib/

Revert the recent change that used the above repo for all arches. We need
arch-specific builder arches on non-intel. Update unit tests to cover this
change.