### PR TITLE
bigtop repo url fixes

### DIFF
--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -167,9 +167,10 @@ class Bigtop(object):
                 arch=repo_arch
             )
         elif bigtop_version == '1.2.1':
-            # NB: Kafka is no longer served from official repos, nor are there
-            # non-x86 repos available for 1.2.1. Handle these cases by using
-            # the bigtop CI repository.
+            # NB: Kafka is no longer served from official repos [1], nor are
+            # there non-x86 repos available for 1.2.1. Handle these cases by
+            # using the bigtop CI repository.
+            # [1]: http://mail-archives.apache.org/mod_mbox/bigtop-announce/201708.mbox/thread
             if hookenv.metadata()['name'] == 'kafka' or repo_arch != "x86_64":
                 bigtop_repo_url = ('https://ci.bigtop.apache.org/'
                                    'job/Bigtop-1.2.1/'


### PR DESCRIPTION
Revert pieces of #66. For bigtop 1.1.0 and 1.2.0, the correct repos
are still using bigtop-repos.s3. See the relevant bigtop.list at our
source of truth:

https://www.apache.org/dist/bigtop/

Set default release/series to 16.04/xenial. These are installable on
non-LTS releases, and are required to match the current bigtop repo
layout.

Remove useless checks for dist_name == 'ubuntu' since we fail fast
if someone tries to deploy a charm on non-ubuntu.

Kafka and non-intel are no longer available in the official repos
after 1.2. Ensure those cases are handled by setting the repo to the
correct CI repository.

Update the unit tests to deal with the above.