### PR TITLE
Install nvidia cuda on capable hardware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ clean:
 	@rm -rf .cache
 	@rm -f .coverage
 	@rm -rf .tox
+	@find . -name "*.pyc" -type f -exec rm -f '{}' \;
 	@find . -name "__pycache__" -type d -prune -exec rm -rf '{}' \;
 
 .PHONY: sysdeps

--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,8 @@ options:
         upstream bits.
   install-cuda:
     type: boolean
-    default: false
+    default: True
     description: |
-      Install the CUDA binaries if capable hardware is present. This option
-      is False by default, as not all applications support GPU acceleration.
+      Install the CUDA binaries if capable hardware is present (True by
+      default). Set to False to disable CUDA installation regardless of
+      capable hardware.


### PR DESCRIPTION
Switch the `install-cuda` default to True. If capable hardware is present,
CUDA should be automatically installed. Without this, users that deploy
to gpu instances have to explicitly configure `install-cuda=True`.

Setting this to True is a no-op on non-gpu hardware as layer-nvidia-cuda
will not do anything unless `lspci` detects an available gpu.

If an operator really wants GPU hardware without CUDA, they can always
configure with `install-cuda=False`.

... also get rid of pesky .pyc in our Makefile 'clean' target.