### PR TITLE
set a more stable repo for 1.2.1/kafka

### DIFF
--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -173,8 +173,8 @@ class Bigtop(object):
             # [1]: http://mail-archives.apache.org/mod_mbox/bigtop-announce/201708.mbox/thread
             if hookenv.metadata()['name'] == 'kafka' or repo_arch != "x86_64":
                 bigtop_repo_url = ('https://ci.bigtop.apache.org/'
-                                   'job/Bigtop-1.2.1/'
-                                   'OS=ubuntu-16.04/ws/output/apt')
+                                   'job/Bigtop-1.2.1/OS=ubuntu-16.04/'
+                                   'lastSuccessfulBuild/artifact/output/apt')
             else:
                 repo_url = ('http://repos.bigtop.apache.org/releases/'
                             '{version}/{dist}/{release}/{arch}')

--- a/tests/unit/test_bigtop.py
+++ b/tests/unit/test_bigtop.py
@@ -141,7 +141,7 @@ class TestBigtopUnit(Harness):
         mock_utils.cpu_arch.return_value = 'foo'
         self.assertEqual(self.bigtop.get_repo_url('1.2.1'),
                          ('https://ci.bigtop.apache.org/job/Bigtop-1.2.1/'
-                          'OS=ubuntu-16.04/ws/output/apt'))
+                          'OS=ubuntu-16.04/lastSuccessfulBuild/artifact/output/apt'))
 
         # master on xenial/intel
         mock_ver.return_value = 'master'


### PR DESCRIPTION
Looks like the workspace for repo jobs gets reaped, which means kafka and non-intel deployments may fail if a recent workspace isn't available.  Adjust repos to `lastSuccessfulBuild/artifact/` for these scenarios:

https://ci.bigtop.apache.org/job/Bigtop-1.2.1/OS=ubuntu-16.04/lastSuccessfulBuild/artifact/output/apt/