### PR TITLE
use current conventions from layer-basic

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ includes: ['layer:apache-bigtop-base']
 
 This will fetch the layer from [interfaces.juju.solutions][] and
 incorporate it into your charm. To use the Bigtop class, import it,
-then call its `.render_site_yaml` and `.trigger_puppet` routines in
-sequence, like so (you might notice that Bigtop also has an `.install`
-routine -- this is run automatically in the reactive handlers of this
+then call its `render_site_yaml` and `trigger_puppet` methods in
+sequence, like so (you might notice that Bigtop also has an `install`
+method -- this is run automatically in the reactive handlers of this
 layer; you don't need to call it yourself):
 
 [interfaces.juju.solutions]: http://interfaces.juju.solutions/
 
 ```python
-from charms.layer.apache_bigtop_base import Bigtop
+from charms import layer
 
 # Setup arguments to pass to .render_site_yaml
 hosts = {'some_bigtop_service': <host>}
@@ -36,7 +36,7 @@ roles = ['some_bigtop_service_nodetype0', 'some_bigtop_service_nodetype1']
 override = {'some_bigtop_service::somekey': <somevalue>, ...}
 
 # Trigger a puppet run
-bigtop = Bigtop()
+bigtop = layer.apache_bigtop_base.Bigtop()
 bigtop.render_site_yaml(hosts, roles, override)
 bigtop.trigger_puppet()
 ```
@@ -44,7 +44,7 @@ bigtop.trigger_puppet()
 This tells Bigtop to run puppet and install your service.
 
 How does Bigtop know what to install? You tell it what to install by
-passing a list of *roles* to `.render_site_yaml`. You may wish to
+passing a list of *roles* to `render_site_yaml`. You may wish to
 consult [this list of valid roles][roles] to see what is available.
 
 [roles]: https://github.com/apache/bigtop/blob/master/bigtop-deploy/puppet/manifests/cluster.pp)
@@ -52,7 +52,7 @@ consult [this list of valid roles][roles] to see what is available.
 > **Note**: Bigtop is also able to generate a list of roles from a
 *component*. The Bigtop class is theoretically able to infer
 components from the *hosts* dict that you pass to
-`.render_site_yaml`. As of this writing, this code path is not well
+`render_site_yaml`. As of this writing, this code path is not well
 tested, so you may want to specify roles explicitly. [List of
 valid components][components].
 

--- a/actions/reinstall
+++ b/actions/reinstall
@@ -27,7 +27,7 @@
 import sys
 
 from charmhelpers.core import hookenv, unitdata
-from charms.layer.apache_bigtop_base import Bigtop
+from charms import layer
 from charms.reactive import is_state
 
 
@@ -47,7 +47,7 @@ if not is_state('bigtop.version.changed'):
 if not unitdata.kv().get('<CHARM>.version.repo', False):
     fail('Charm is not prepared to run the reinstall action.')
 
-bigtop = Bigtop()
+bigtop = layer.apache_bigtop_base.Bigtop()
 result = bigtop.reinstall_repo_packages()
 
 if result == 'success':

--- a/actions/smoke-test
+++ b/actions/smoke-test
@@ -27,7 +27,6 @@ import sys
 
 from charmhelpers.core import hookenv
 from charms import layer
-from charms.layer.apache_bigtop_base import Bigtop
 from charms.reactive import is_state
 
 
@@ -40,12 +39,12 @@ def fail(msg):
 if not is_state('bigtop.available'):
     fail('Bigtop is not yet ready')
 
-cfg = layer.options('apache-bigtop-base')
+cfg = layer.options.get('apache-bigtop-base')
 smoke_components = cfg.get('bigtop_smoketest_components')
 if not smoke_components:
     fail('No bigtop_smoketest_components found for this charm')
 
-bigtop = Bigtop()
+bigtop = layer.apache_bigtop_base.Bigtop()
 result = bigtop.run_smoke_tests(smoke_components)
 if result == 'success':
     hookenv.action_set({'outcome': 'success'})

--- a/lib/charms/layer/apache_bigtop_base.py
+++ b/lib/charms/layer/apache_bigtop_base.py
@@ -56,7 +56,7 @@ class Bigtop(object):
 
     def __init__(self):
         self.bigtop_dir = '/home/ubuntu/bigtop.release'
-        self.options = layer.options('apache-bigtop-base')
+        self.options = layer.options.get('apache-bigtop-base')
         self._bigtop_version = hookenv.config()['bigtop_version']
         self._bigtop_apt = self.get_repo_url(self.bigtop_version)
         self._bigtop_base = Path(self.bigtop_dir) / 'bigtop-{}'.format(
@@ -925,8 +925,8 @@ def java_home():
     java_home = unitdata.kv().get('java_home')
 
     # Otherwise, check to see if we've asked bigtop to install java.
-    options = layer.options('apache-bigtop-base')
-    if java_home is None and options.get('install_java'):
+    install_java = layer.options.get('apache-bigtop-base', 'install_java')
+    if java_home is None and install_java:
         # Figure out where java got installed. This should work in
         # both recent Debian and recent Redhat based distros.
         if os.path.exists('/etc/alternatives/java'):
@@ -936,7 +936,7 @@ def java_home():
 
 
 def get_layer_opts():
-    return utils.DistConfig(data=layer.options('apache-bigtop-base'))
+    return utils.DistConfig(data=layer.options.get('apache-bigtop-base'))
 
 
 def get_fqdn():

--- a/reactive/apache_bigtop_base.py
+++ b/reactive/apache_bigtop_base.py
@@ -11,11 +11,15 @@ from jujubigdata import utils
 
 @when_none('java.ready', 'hadoop-plugin.java.ready', 'hadoop-rest.joined')
 def missing_java():
-    if layer.options('apache-bigtop-base').get('install_java'):
+    if layer.options.get('apache-bigtop-base', 'install_java'):
+        # layer.yaml has told us to install java in this layer.
         set_state('install_java')
     elif any_states('java.joined', 'hadoop-plugin.joined'):
+        # a java charm and/or hadoop-plugin will be installing java, but they
+        # are not ready yet. set appropriate status.
         hookenv.status_set('waiting', 'waiting on java')
     else:
+        # if we make it here, we're blocked until related to a java charm.
         hookenv.status_set('blocked', 'waiting on relation to java')
 
 

--- a/reactive/apache_bigtop_base.py
+++ b/reactive/apache_bigtop_base.py
@@ -5,7 +5,6 @@ from charmhelpers.core import hookenv, unitdata
 from charmhelpers.core.host import ChecksumError
 from charmhelpers.fetch import UnhandledSource
 from charms import layer
-from charms.layer.apache_bigtop_base import Bigtop
 from jujubigdata import utils
 
 
@@ -28,7 +27,7 @@ def missing_java():
 def fetch_bigtop():
     hookenv.status_set('maintenance', 'installing apache bigtop base')
     try:
-        Bigtop().install()
+        layer.apache_bigtop_base.Bigtop().install()
     except UnhandledSource as e:
         hookenv.status_set('blocked', 'unable to fetch apache bigtop: %s' % e)
     except ChecksumError:
@@ -56,7 +55,7 @@ def change_bigtop_version():
     if pre_ver and cur_ver != pre_ver:
         hookenv.log('Bigtop version {} requested over {}. Refreshing source.'
                     .format(cur_ver, pre_ver))
-        Bigtop().refresh_bigtop_release()
+        layer.apache_bigtop_base.Bigtop().refresh_bigtop_release()
         hookenv.status_set('waiting', 'pending scan for package updates')
         set_state('bigtop.version.changed')
 

--- a/tests/unit/test_bigtop.py
+++ b/tests/unit/test_bigtop.py
@@ -189,7 +189,7 @@ class TestBigtopUnit(Harness):
         '''
         mock_lsb_release.return_value = {'DISTRIB_CODENAME': 'xenial'}
 
-        # Should be noop if bigtop_jdk not set.
+        # Should be noop if install_java layer opt is not set.
         self.bigtop.options.get.return_value = ''
         self.bigtop.install_java()
 
@@ -198,7 +198,7 @@ class TestBigtopUnit(Harness):
         self.assertFalse(mock_fetch.apt_install.called)
         self.assertFalse(mock_utils.re_edit_in_place.called)
 
-        # Should add ppa if we have set bigtop_jdk.
+        # Should apt install if install_java layer opt is set.
         self.bigtop.options.get.return_value = 'foo'
         print("options: {}".format(self.bigtop.options))
         self.bigtop.install_java()
@@ -728,7 +728,7 @@ class TestHelpers(Harness):
     @mock.patch('charms.layer.apache_bigtop_base.layer.options')
     def test_get_layer_opts(self, mock_options):
         '''Verify that we parse whatever dict we get back from options.'''
-        mock_options.return_value = {'foo': 'bar'}
+        mock_options.get.return_value = {'foo': 'bar'}
         ret = get_layer_opts()
         self.assertEqual(ret.dist_config['foo'], 'bar')
 

--- a/tests/unit/test_reactive_handlers.py
+++ b/tests/unit/test_reactive_handlers.py
@@ -22,31 +22,29 @@ class TestMissingJava(Harness):
     @mock.patch('apache_bigtop_base.hookenv.status_set')
     def test_missing_java(self, mock_status, mock_options):
         '''
-        Test to verify that our missing_java function kicks us into a
-        'waiting' state if 'java.joined' is set, or tells us that
-        we're blocked if it is not.
-
-        In the case of install_java being set, verify that we instead
-        set the install_java state, and set no status.
+        Test to verify that our missing_java function sets an appropriate
+        state or status message.
 
         '''
         mock_status.side_effect = self.status_set
-        mock_options.return_value = {'install_java': 'foo'}
 
+        # Test install_java is set
+        mock_options.get.return_value = {'foo'}
         missing_java()
         self.assertTrue(is_state('install_java'))
         self.assertFalse(self.last_status[0])
 
-        mock_options.return_value = {'install_java': ''}
-
-        set_state('some.state')
+        # Test neither install_java nor java states are set
+        mock_options.get.return_value = {}
         missing_java()
         self.assertEqual(self.last_status[0], 'blocked')
 
+        # Test install_java is not set, but we do have a java state
         set_state('java.joined', 'some.other.state')
         missing_java()
         self.assertEqual(self.last_status[0], 'waiting')
 
+        # Test install_java is not set, and our java state has gone away
         remove_state('java.joined')
         missing_java()
         self.assertEqual(self.last_status[0], 'blocked')

--- a/tests/unit/test_reactive_handlers.py
+++ b/tests/unit/test_reactive_handlers.py
@@ -57,7 +57,7 @@ class TestFetchBigtop(Harness):
     '''
     def setUp(self):
         super(TestFetchBigtop, self).setUp()
-        self.bigtop_patcher = mock.patch('apache_bigtop_base.Bigtop')
+        self.bigtop_patcher = mock.patch('charms.layer.apache_bigtop_base.Bigtop')
         mock_bigtop_class = self.bigtop_patcher.start()
         self.mock_bigtop = mock.Mock()
         mock_bigtop_class.return_value = self.mock_bigtop
@@ -102,7 +102,7 @@ class TestChangeBigtopVersion(Harness):
     '''
     def setUp(self):
         super(TestChangeBigtopVersion, self).setUp()
-        self.bigtop_patcher = mock.patch('apache_bigtop_base.Bigtop')
+        self.bigtop_patcher = mock.patch('charms.layer.apache_bigtop_base.Bigtop')
         mock_bigtop_class = self.bigtop_patcher.start()
         self.mock_bigtop = mock.Mock()
         mock_bigtop_class.return_value = self.mock_bigtop


### PR DESCRIPTION
Recent updates to layer-basic include new conventions for dealing with layers.  First, now that layer-basic pulls in layer-options, let's do like the README says:

https://github.com/juju-solutions/layer-options
```
    foo_opts = layer.options.get('foo')  # returns a dict of all the options
    my_opt_1 = layer.options.get('foo', 'my_opt_1')  # returns just that option
```

Next, the [layer lib import convention](https://github.com/juju-solutions/layer-basic/pull/112) is to use `from charms import layer` followed by `layer.foo` to make the namespace of functions stand out a bit better. The old style still works, but we may as well future-proof before some little data spills out.